### PR TITLE
Removing crossdomain.xml requests from samples

### DIFF
--- a/src/basic-samples/BasicReplier/BasicReplier.js
+++ b/src/basic-samples/BasicReplier/BasicReplier.js
@@ -119,13 +119,8 @@ var BasicReplier = function (topicName) {
                 replier.log(error.toString());
             }
         });
-        // if secure connection, first load iframe so the browser can provide a client-certificate
-        if (hosturl.lastIndexOf('wss://', 0) === 0 || hosturl.lastIndexOf('https://', 0) === 0) {
-            var urlNoProto = hosturl.split('/').slice(2).join('/'); // remove protocol prefix
-            document.getElementById('iframe').src = 'https://' + urlNoProto + '/crossdomain.xml';
-        } else {
-            replier.connectToSolace();   // otherwise proceed
-        }
+
+        replier.connectToSolace();   
     };
 
     // Actually connects the session triggered when the iframe has been loaded - see in html code

--- a/src/basic-samples/BasicRequestor/BasicRequestor.js
+++ b/src/basic-samples/BasicRequestor/BasicRequestor.js
@@ -97,13 +97,8 @@ var BasicRequestor = function (topicName) {
                 requestor.session = null;
             }
         });
-        // if secure connection, first load iframe so the browser can provide a client-certificate
-        if (hosturl.lastIndexOf('wss://', 0) === 0 || hosturl.lastIndexOf('https://', 0) === 0) {
-            var urlNoProto = hosturl.split('/').slice(2).join('/'); // remove protocol prefix
-            document.getElementById('iframe').src = 'https://' + urlNoProto + '/crossdomain.xml';
-        } else {
-            requestor.connectToSolace();   // otherwise proceed
-        }
+
+        requestor.connectToSolace();   
     };
 
     // Actually connects the session triggered when the iframe has been loaded - see in html code

--- a/src/basic-samples/ConfirmedPublish/ConfirmedPublish.js
+++ b/src/basic-samples/ConfirmedPublish/ConfirmedPublish.js
@@ -107,13 +107,9 @@ var QueueProducer = function (queueName) {
                 producer.session = null;
             }
         });
-        // if secure connection, first load iframe so the browser can provide a client-certificate
-        if (hosturl.lastIndexOf('wss://', 0) === 0 || hosturl.lastIndexOf('https://', 0) === 0) {
-            var urlNoProto = hosturl.split('/').slice(2).join('/'); // remove protocol prefix
-            document.getElementById('iframe').src = 'https://' + urlNoProto + '/crossdomain.xml';
-        } else {
-            producer.connectToSolace();   // otherwise proceed
-        }
+
+        producer.connectToSolace();   
+
     };
 
     // Actually connects the session triggered when the iframe has been loaded - see in html code

--- a/src/basic-samples/QueueConsumer/QueueConsumer.js
+++ b/src/basic-samples/QueueConsumer/QueueConsumer.js
@@ -100,13 +100,9 @@ var QueueConsumer = function (queueName) {
                 consumer.session = null;
             }
         });
-        // if secure connection, first load iframe so the browser can provide a client-certificate
-        if (hosturl.lastIndexOf('wss://', 0) === 0 || hosturl.lastIndexOf('https://', 0) === 0) {
-            var urlNoProto = hosturl.split('/').slice(2).join('/'); // remove protocol prefix
-            document.getElementById('iframe').src = 'https://' + urlNoProto + '/crossdomain.xml';
-        } else {
-            consumer.connectToSolace();   // otherwise proceed
-        }
+
+        consumer.connectToSolace();   
+
     };
 
     // Actually connects the session triggered when the iframe has been loaded - see in html code

--- a/src/basic-samples/QueueProducer/QueueProducer.js
+++ b/src/basic-samples/QueueProducer/QueueProducer.js
@@ -98,13 +98,9 @@ var QueueProducer = function (queueName) {
                 producer.session = null;
             }
         });
-        // if secure connection, first load iframe so the browser can provide a client-certificate
-        if (hosturl.lastIndexOf('wss://', 0) === 0 || hosturl.lastIndexOf('https://', 0) === 0) {
-            var urlNoProto = hosturl.split('/').slice(2).join('/'); // remove protocol prefix
-            document.getElementById('iframe').src = 'https://' + urlNoProto + '/crossdomain.xml';
-        } else {
-            producer.connectToSolace();   // otherwise proceed
-        }
+
+        producer.connectToSolace();   
+
     };
 
     // Actually connects the session triggered when the iframe has been loaded - see in html code

--- a/src/basic-samples/TopicPublisher/TopicPublisher.js
+++ b/src/basic-samples/TopicPublisher/TopicPublisher.js
@@ -97,13 +97,9 @@ var TopicPublisher = function (topicName) {
                 publisher.session = null;
             }
         });
-        // if secure connection, first load iframe so the browser can provide a client-certificate
-        if (hosturl.lastIndexOf('wss://', 0) === 0 || hosturl.lastIndexOf('https://', 0) === 0) {
-            var urlNoProto = hosturl.split('/').slice(2).join('/'); // remove protocol prefix
-            document.getElementById('iframe').src = 'https://' + urlNoProto + '/crossdomain.xml';
-        } else {
-            publisher.connectToSolace();   // otherwise proceed
-        }
+
+        publisher.connectToSolace();   
+
     };
 
     // Actually connects the session triggered when the iframe has been loaded - see in html code

--- a/src/basic-samples/TopicSubscriber/TopicSubscriber.js
+++ b/src/basic-samples/TopicSubscriber/TopicSubscriber.js
@@ -117,13 +117,12 @@ var TopicSubscriber = function (topicName) {
             subscriber.log('Received message: "' + message.getBinaryAttachment() + '", details:\n' +
                 message.dump());
         });
-        // if secure connection, first load iframe so the browser can provide a client-certificate
-        if (hosturl.lastIndexOf('wss://', 0) === 0 || hosturl.lastIndexOf('https://', 0) === 0) {
-            var urlNoProto = hosturl.split('/').slice(2).join('/'); // remove protocol prefix
-            document.getElementById('iframe').src = 'https://' + urlNoProto + '/crossdomain.xml';
-        } else {
-            subscriber.connectToSolace();   // otherwise proceed
-        }
+
+
+       subscriber.connectToSolace();   
+
+
+
     };
 
     // Actually connects the session triggered when the iframe has been loaded - see in html code

--- a/src/features/ActiveConsumerIndication/ActiveConsumerIndication.js
+++ b/src/features/ActiveConsumerIndication/ActiveConsumerIndication.js
@@ -115,13 +115,9 @@ var QueueConsumer = function (queueName) {
                 sample.session = null;
             }
         });
-        // if secure connection, first load iframe so the browser can provide a client-certificate
-        if (hosturl.lastIndexOf('wss://', 0) === 0 || hosturl.lastIndexOf('https://', 0) === 0) {
-            var urlNoProto = hosturl.split('/').slice(2).join('/'); // remove protocol prefix
-            document.getElementById('iframe').src = 'https://' + urlNoProto + '/crossdomain.xml';
-        } else {
-            sample.connectToSolace();   // otherwise proceed
-        }
+
+        sample.connectToSolace();   
+
     };
 
     // Actually connects the session triggered when the iframe has been loaded - see in html code

--- a/src/features/DTEConsumer/DTEConsumer.js
+++ b/src/features/DTEConsumer/DTEConsumer.js
@@ -108,13 +108,9 @@ var DTEConsumer = function (topicEndpointName, topicName) {
                 consumer.session = null;
             }
         });
-        // if secure connection, first load iframe so the browser can provide a client-certificate
-        if (hosturl.lastIndexOf('wss://', 0) === 0 || hosturl.lastIndexOf('https://', 0) === 0) {
-            var urlNoProto = hosturl.split('/').slice(2).join('/'); // remove protocol prefix
-            document.getElementById('iframe').src = 'https://' + urlNoProto + '/crossdomain.xml';
-        } else {
-            consumer.connectToSolace();   // otherwise proceed
-        }
+
+        consumer.connectToSolace();   
+
     };
 
     // Actually connects the session triggered when the iframe has been loaded - see in html code

--- a/src/features/EventMonitor/EventMonitor.js
+++ b/src/features/EventMonitor/EventMonitor.js
@@ -124,13 +124,9 @@ var EventSubscriber = function () {
         subscriber.session.on(solace.SessionEventCode.MESSAGE, function (message) {
             subscriber.log('Received Client Connect event: "' + message.getBinaryAttachment());
         });
-        // if secure connection, first load iframe so the browser can provide a client-certificate
-        if (hosturl.lastIndexOf('wss://', 0) === 0 || hosturl.lastIndexOf('https://', 0) === 0) {
-            var urlNoProto = hosturl.split('/').slice(2).join('/'); // remove protocol prefix
-            document.getElementById('iframe').src = 'https://' + urlNoProto + '/crossdomain.xml';
-        } else {
-            subscriber.connectToSolace();   // otherwise proceed
-        }
+
+        subscriber.connectToSolace();   
+
     };
 
     // Actually connects the session triggered when the iframe has been loaded - see in html code

--- a/src/features/GuaranteedReplier/GuaranteedReplier.js
+++ b/src/features/GuaranteedReplier/GuaranteedReplier.js
@@ -109,13 +109,9 @@ var GuaranteedReplier = function (requestTopicName) {
                 replier.session = null;
             }
         });
-        // if secure connection, first load iframe so the browser can provide a client-certificate
-        if (hosturl.lastIndexOf('wss://', 0) === 0 || hosturl.lastIndexOf('https://', 0) === 0) {
-            var urlNoProto = hosturl.split('/').slice(2).join('/'); // remove protocol prefix
-            document.getElementById('iframe').src = 'https://' + urlNoProto + '/crossdomain.xml';
-        } else {
-            replier.connectToSolace();   // otherwise proceed
-        }
+
+        replier.connectToSolace();   
+
     };
 
     // Actually connects the session triggered when the iframe has been loaded - see in html code

--- a/src/features/GuaranteedRequestor/GuaranteedRequestor.js
+++ b/src/features/GuaranteedRequestor/GuaranteedRequestor.js
@@ -106,13 +106,9 @@ var GuaranteedRequestor = function (requestTopicName) {
                 requestor.session = null;
             }
         });
-        // if secure connection, first load iframe so the browser can provide a client-certificate
-        if (hosturl.lastIndexOf('wss://', 0) === 0 || hosturl.lastIndexOf('https://', 0) === 0) {
-            var urlNoProto = hosturl.split('/').slice(2).join('/'); // remove protocol prefix
-            document.getElementById('iframe').src = 'https://' + urlNoProto + '/crossdomain.xml';
-        } else {
-            requestor.connectToSolace();   // otherwise proceed
-        }
+
+        requestor.connectToSolace();   
+
     };
 
     // Actually connects the session triggered when the iframe has been loaded - see in html code

--- a/src/features/NoLocalPubSub/NoLocalPubSub.js
+++ b/src/features/NoLocalPubSub/NoLocalPubSub.js
@@ -91,13 +91,9 @@ var NoLocalPubSub = function (topicName) {
             userName: username,
             password: pass,
         });
-        // if secure connection, first load iframe so the browser can provide a client-certificate
-        if (hosturl.lastIndexOf('wss://', 0) === 0 || hosturl.lastIndexOf('https://', 0) === 0) {
-            var urlNoProto = hosturl.split('/').slice(2).join('/'); // remove protocol prefix
-            document.getElementById('iframe').src = 'https://' + urlNoProto + '/crossdomain.xml';
-        } else {
-            sample.connectToSolace();   // otherwise proceed
-        }
+
+        sample.connectToSolace();   // otherwise proceed
+
     };
 
     // Actually connects the session triggered when the iframe has been loaded - see in html code

--- a/src/features/SecureSession/SecureSession.js
+++ b/src/features/SecureSession/SecureSession.js
@@ -21,10 +21,6 @@
  * Solace Web Messaging API for JavaScript
  * Secure Session tutorial
  * Demonstrates the use of secure session
- * The web application user may need to select or cancel selection of a
- * client certificate to use in a popup window - triggered by an invisible
- * iframe connecting securely to the server. This is necessary because the
- * message router is always requesting a client certificate.
  */
 
 /*jslint es6 browser devel:true*/
@@ -121,9 +117,6 @@ var SecureTopicSubscriber = function (topicName) {
             subscriber.log('Received message: "' + message.getBinaryAttachment() + '", details:\n' +
                 message.dump());
         });
-        // if secure connection, first load iframe so the browser can provide a client-certificate
-        var urlNoProto = hosturl.split('/').slice(2).join('/'); // remove protocol prefix
-        document.getElementById('iframe').src = 'https://' + urlNoProto + '/crossdomain.xml';
     };
 
     // Actually connects the session triggered when the iframe has been loaded - see in html code


### PR DESCRIPTION
This code was a workaround for the client-certificate challenge issue in earlier versions of the VMR/appliance. This is resolved in recent software versions, so it is no longer necessary. 

In addition, there may be issues with recent VMR loads responding promptly to the request for crossdomain.xml. Note that this file is not needed for Javascript to operate correctly. It is only used by ActionScript/Flash. 

I have removed this workaround from all files.