### PR TITLE
JS Sample update on Guaranteed Publisher/Subscriber and Queue Producer/Consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The "Getting Started" tutorials will get you up to speed and sending messages wi
 
 - Follow [these instructions](https://cloud.solace.com/learn/group_getting_started/ggs_signup.html) to quickly spin up a cloud-based Solace messaging service for your applications.
 - Follow [these instructions](https://docs.solace.com/Solace-SW-Broker-Set-Up/Setting-Up-SW-Brokers.htm) to start the Solace PubSub+ software event broker in leading Clouds, Container Platforms or Hypervisors. The tutorials outline where to download and how to install the Solace PubSub+ software event broker.
-- If your company has Solace message routers deployed, contact your middleware team to obtain the host name or IP address of a Solace message router to test against, a username and password to access it, and a VPN in which you can produce and consume messages.
+- If your company has Solace PubSub+ Event Brokers deployed, contact your middleware team to obtain the host name or IP address of a Solace PubSub+ Event Broker to test against, a username and password to access it, and a VPN in which you can produce and consume messages.
 
 ## Contents
 
@@ -19,10 +19,10 @@ This repository contains:
     - [Publish/Subscribe](https://tutorials.solace.dev/javascript/publish-subscribe/): Learn how to set up pub/sub messaging on a Solace PubSub+ software event broker.
     - [Persistence](https://tutorials.solace.dev/javascript/persistence-with-queues/): Learn how to set up persistence for guaranteed delivery.
     - [Request/Reply](https://tutorials.solace.dev/javascript/request-reply/): Learn how to set up request/reply messaging.
-    - [Confirmed Delivery](https://tutorials.solace.dev/javascript/confirmed-delivery/): Learn how to confirm that your messages are received by a Solace message router.
+    - [Confirmed Delivery](https://tutorials.solace.dev/javascript/confirmed-delivery/): Learn how to confirm that your messages are received by a Solace PubSub+ Event Broker.
     - [Topic to Queue Mapping](https://tutorials.solace.dev/javascript/topic-to-queue-mapping/): Learn how to map existing topics to Solace queues.
 
-* The following additional samples showing how to make use of advanced features of the Solace message router.
+* The following additional samples showing how to make use of advanced features of the Solace PubSub+ Event Broker.
 
     - [Secure Session](https://github.com/SolaceSamples/solace-samples-javascript/tree/master/src/features/SecureSession): Learn how to use secure connection to the server and server and client certificate authentication.
     - [Active Consumer Indication](https://tutorials.solace.dev/javascript/active-consumer-indication/): Learn how multiple consumers can bind to an exclusive queue, but only one client at a time can actively receive messages.

--- a/src/basic-samples/BasicReplier/BasicReplier.js
+++ b/src/basic-samples/BasicReplier/BasicReplier.js
@@ -47,7 +47,7 @@ var BasicReplier = function (topicName) {
 
     replier.log('\n*** replier to topic "' + replier.topicName + '" is ready to connect ***');
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     replier.connect = function () {
         if (replier.session !== null) {
             replier.log('Already connected and ready to ready to receive requests.');
@@ -64,12 +64,12 @@ var BasicReplier = function (topicName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            replier.log('Cannot connect: please specify all the Solace message router properties.');
+            replier.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        replier.log('Connecting to Solace message router using url: ' + hosturl);
+        replier.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         replier.log('Client username: ' + username);
-        replier.log('Solace message router VPN name: ' + vpn);
+        replier.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             replier.session = solace.SolclientFactory.createSession({
@@ -132,7 +132,7 @@ var BasicReplier = function (topicName) {
         }
     };
 
-    // Subscribes to request topic on Solace message router
+    // Subscribes to request topic on Solace PubSub+ Event Broker
     replier.subscribe = function () {
         if (replier.session !== null) {
             if (replier.subscribed) {
@@ -151,11 +151,11 @@ var BasicReplier = function (topicName) {
                 }
             }
         } else {
-            replier.log('Cannot subscribe because not connected to Solace message router.');
+            replier.log('Cannot subscribe because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Unsubscribes from request topic on Solace message router
+    // Unsubscribes from request topic on Solace PubSub+ Event Broker
     replier.unsubscribe = function () {
         if (replier.session !== null) {
             if (replier.subscribed) {
@@ -174,7 +174,7 @@ var BasicReplier = function (topicName) {
                 replier.log('Cannot unsubscribe because not subscribed to the topic "' + replier.topicName + '"');
             }
         } else {
-            replier.log('Cannot unsubscribe because not connected to Solace message router.');
+            replier.log('Cannot unsubscribe because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
@@ -191,13 +191,13 @@ var BasicReplier = function (topicName) {
                 replier.log('Replied.');
             }
         } else {
-            replier.log('Cannot reply: not connected to Solace message router.');
+            replier.log('Cannot reply: not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     replier.disconnect = function () {
-        replier.log('Disconnecting from Solace message router...');
+        replier.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (replier.session !== null) {
             try {
                 replier.session.disconnect();
@@ -205,7 +205,7 @@ var BasicReplier = function (topicName) {
                 replier.log(error.toString());
             }
         } else {
-            replier.log('Not connected to Solace message router.');
+            replier.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
 

--- a/src/basic-samples/BasicRequestor/BasicRequestor.js
+++ b/src/basic-samples/BasicRequestor/BasicRequestor.js
@@ -46,7 +46,7 @@ var BasicRequestor = function (topicName) {
 
     requestor.log('\n*** requestor to topic "' + requestor.topicName + '" is ready to connect ***');
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     requestor.connect = function () {
         if (requestor.session !== null) {
             requestor.log('Already connected and ready to send requests.');
@@ -63,12 +63,12 @@ var BasicRequestor = function (topicName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            session.log('Cannot connect: please specify all the Solace message router properties.');
+            session.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        requestor.log('Connecting to Solace message router using url: ' + hosturl);
+        requestor.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         requestor.log('Client username: ' + username);
-        requestor.log('Solace message router VPN name: ' + vpn);
+        requestor.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             requestor.session = solace.SolclientFactory.createSession({
@@ -135,7 +135,7 @@ var BasicRequestor = function (topicName) {
                 requestor.log(error.toString());
             }
         } else {
-            requestor.log('Cannot send request because not connected to Solace message router.');
+            requestor.log('Cannot send request because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
@@ -150,9 +150,9 @@ var BasicRequestor = function (topicName) {
         requestor.log('Request failure: ' + event.toString());
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     requestor.disconnect = function () {
-        requestor.log('Disconnecting from Solace message router...');
+        requestor.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (requestor.session !== null) {
             try {
                 requestor.session.disconnect();
@@ -160,7 +160,7 @@ var BasicRequestor = function (topicName) {
                 requestor.log(error.toString());
             }
         } else {
-            requestor.log('Not connected to Solace message router.');
+            requestor.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
     

--- a/src/basic-samples/ConfirmedPublish/ConfirmedPublish.js
+++ b/src/basic-samples/ConfirmedPublish/ConfirmedPublish.js
@@ -46,7 +46,7 @@ var QueueProducer = function (queueName) {
 
     producer.log('\n*** Producer to queue "' + producer.queueName + '" is ready to connect ***');
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     producer.connect = function () {
         if (producer.session !== null) {
             producer.log('Already connected and ready to send messages.');
@@ -63,12 +63,12 @@ var QueueProducer = function (queueName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            producer.log('Cannot connect: please specify all the Solace message router properties.');
+            producer.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        producer.log('Connecting to Solace message router using url: ' + hosturl);
+        producer.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         producer.log('Client username: ' + username);
-        producer.log('Solace message router VPN name: ' + vpn);
+        producer.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             producer.session = solace.SolclientFactory.createSession({
@@ -127,7 +127,7 @@ var QueueProducer = function (queueName) {
                 producer.sendMessage(i);
             }
         } else {
-            producer.log('Cannot send messages because not connected to Solace message router.');
+            producer.log('Cannot send messages because not connected to Solace PubSub+ Event Broker.');
         }
     }
 
@@ -152,9 +152,9 @@ var QueueProducer = function (queueName) {
         }
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     producer.disconnect = function () {
-        producer.log('Disconnecting from Solace message router...');
+        producer.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (producer.session !== null) {
             try {
                 producer.session.disconnect();
@@ -162,7 +162,7 @@ var QueueProducer = function (queueName) {
                 producer.log(error.toString());
             }
         } else {
-            producer.log('Not connected to Solace message router.');
+            producer.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
 

--- a/src/basic-samples/GuaranteedPublisher/GuaranteedPublisher.html
+++ b/src/basic-samples/GuaranteedPublisher/GuaranteedPublisher.html
@@ -54,7 +54,7 @@
         solace.SolclientFactory.setLogLevel(solace.LogLevel.WARN);
 
         // create the publisher, specifying name of the topic
-        publisher = new GuaranteedPublisher('solace/samples/js/pers/pub');
+        publisher = new GuaranteedPublisher('solace/samples/js/pers');
         // assign buttons to the publisher functions
         document.getElementById("connect").addEventListener("click", publisher.connect);
         document.getElementById("disconnect").addEventListener("click", publisher.disconnect);

--- a/src/basic-samples/GuaranteedPublisher/GuaranteedPublisher.html
+++ b/src/basic-samples/GuaranteedPublisher/GuaranteedPublisher.html
@@ -8,7 +8,7 @@
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
     
-      http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
     
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
@@ -16,18 +16,18 @@
     KIND, either express or implied.  See the License for the
     specific language governing permissions and limitations
     under the License.
--->
+  -->
 
 <!--
     Solace Web Messaging API for JavaScript
-    Persistence with Queues tutorial - Queue Consumer
-    Demonstrates sending persistent messages to a queue
--->
+    Publishing Guaranteed messages on a Topic tutorial - Guaranteed publisher
+    Demonstrates sending persistent messages on a topic
+  -->
 
 <html lang="en">
 
   <head>
-    <title>Solace Web Messaging API for JavaScript, Persistence with Queues tutorial - Queue Consumer</title>
+    <title>Solace Web Messaging API for JavaScript, Publishing Guaranteed messages on a Topic tutorial - Guaranteed Publisher</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge;" />
     <meta charset="utf-8"/>
 
@@ -37,12 +37,12 @@
     <!-- Load Solace Web Messaging API for JavaScript -->
     <script src="../../../lib/solclient-debug.js"></script>
 
-    <!-- Load the Persistence with Queues - Queue Consumer  -->
-    <script src="QueueConsumer.js"></script>
+    <!-- Load the Guaranteed Publisher  -->
+    <script src="GuaranteedPublisher.js"></script>
 
-    <!-- Execute the PublishSubscribe Topic Subscriber tutorial -->
+    <!-- Execute the Guaranteed Publish on a topic - Guaranteed Publisher tutorial -->
     <script>
-      var subscriber = null;
+      var publisher = null;
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
@@ -53,17 +53,17 @@
         // NOTICE: works only with "solclientjs-debug.js"
         solace.SolclientFactory.setLogLevel(solace.LogLevel.WARN);
 
-        // create the consumer, specifying name of the queue
-        subscriber = new QueueConsumer('tutorial/queue');
-        // assign buttons to the subscriber functions
-        document.getElementById("connect").addEventListener("click", subscriber.connect);
-        document.getElementById("disconnect").addEventListener("click", subscriber.disconnect);
-        document.getElementById("startconsume").addEventListener("click", subscriber.startConsume);
-        document.getElementById("stopconsume").addEventListener("click", subscriber.stopConsume);
+        // create the publisher, specifying name of the topic
+        publisher = new GuaranteedPublisher('solace/samples/js/pers/pub');
+        // assign buttons to the publisher functions
+        document.getElementById("connect").addEventListener("click", publisher.connect);
+        document.getElementById("disconnect").addEventListener("click", publisher.disconnect);
+        document.getElementById("publish").addEventListener("click", publisher.publish);
+        document.getElementById("clear").addEventListener("click", publisher.clear);
       };
       function iframeloaded(){
-        if (subscriber) {
-            subscriber.connectToSolace();
+        if (publisher) {
+          publisher.connectToSolace();
         }
       };
     </script>
@@ -105,8 +105,8 @@
     </div>
 
     <div class="doc-body">
-      <h2>Persistence with Queues tutorial</h2>
-      <h3>Queue Consumer</h3>
+      <h2>Persistence with Topics tutorial</h2>
+      <h3>Guaranteed Publisher</h3>
       <!--[if IE]>
           <div class="ie9 warning" style="padding: 5px; border: 1px solid black; background-color: #ff8;">
               IE9 only: If you are running this sample from the local filesystem, click the "Allow blocked content" button
@@ -117,7 +117,6 @@
           IE 11 only: If you are running this sample from the local filesystem, click the "Allow blocked content" button
           in the popup below to enable JavaScript.
       </div>
-
       <form class="pure-form pure-form-aligned">
         <fieldset>
 
@@ -147,8 +146,8 @@
           <button type="button" class="pure-button button-error" id="disconnect">Disconnect</button>
         </p>
         <p>
-          <button type="button" class="pure-button pure-button-primary" id="startconsume">Consume messages </button>
-          <button type="button" class="pure-button button-error" id="stopconsume">Stop consuming</button>
+          <button type="button" class="pure-button pure-button-primary" id="publish">Send Message </button>
+          <button type="button" class="pure-button pure-button-secondary right" id="clear">Clear</button>
         </p>
         
         <textarea id="log" rows="20" cols="90" autofocus></textarea>
@@ -158,6 +157,6 @@
     </div>
 
   </body>
-  
+
 </html>
 

--- a/src/basic-samples/GuaranteedPublisher/GuaranteedPublisher.js
+++ b/src/basic-samples/GuaranteedPublisher/GuaranteedPublisher.js
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Solace Web Messaging API for JavaScript
+ * Publishing Guaranteed messages on a Topic tutorial - Guaranteed publisher
+ * Demonstrates sending persistent messages on a topic
+ */
+
+/*jslint es6 browser devel:true*/
+/*global solace*/
+
+var GuaranteedPublisher = function (topicName) {
+    'use strict';
+    var publisher = {};
+    publisher.session = null;
+    publisher.topicName = topicName;
+
+    // Logger
+    publisher.log = function (line) {
+        var now = new Date();
+        var time = [('0' + now.getHours()).slice(-2), ('0' + now.getMinutes()).slice(-2),
+            ('0' + now.getSeconds()).slice(-2)];
+        var timestamp = '[' + time.join(':') + '] ';
+        console.log(timestamp + line);
+        var logTextArea = document.getElementById('log');
+        logTextArea.value += timestamp + line + '\n';
+        logTextArea.scrollTop = logTextArea.scrollHeight;
+    };
+
+    publisher.log('\n*** publisher to topic "' + publisher.topicName + '/*" is ready to connect ***');
+
+    // Establishes connection to Solace message router
+    publisher.connect = function () {
+        if (publisher.session !== null) {
+            publisher.log('Already connected and ready to publish messages.');
+            return;
+        }
+        var hosturl = document.getElementById('hosturl').value;
+        // check for valid protocols
+        if (hosturl.lastIndexOf('ws://', 0) !== 0 && hosturl.lastIndexOf('wss://', 0) !== 0 &&
+            hosturl.lastIndexOf('http://', 0) !== 0 && hosturl.lastIndexOf('https://', 0) !== 0) {
+            publisher.log('Invalid protocol - please use one of ws://, wss://, http://, https://');
+            return;
+        }
+        var username = document.getElementById('username').value;
+        var pass = document.getElementById('password').value;
+        var vpn = document.getElementById('message-vpn').value;
+        if (!hosturl || !username || !pass || !vpn) {
+            publisher.log('Cannot connect: please specify all the Solace message router properties.');
+            return;
+        }
+        publisher.log('Connecting to Solace message router using url: ' + hosturl);
+        publisher.log('Client username: ' + username);
+        publisher.log('Solace message router VPN name: ' + vpn);
+        // create session
+        try {
+            publisher.session = solace.SolclientFactory.createSession({
+                // solace.SessionProperties
+                url:      hosturl,
+                vpnName:  vpn,
+                userName: username,
+                password: pass,
+                publisherProperties: {
+                  acknowledgeMode: solace.MessagePublisherAcknowledgeMode.PER_MESSAGE,
+              }          
+            });
+        } catch (error) {
+            publisher.log(error.toString());
+        }
+        // define session event listeners
+        publisher.session.on(solace.SessionEventCode.UP_NOTICE, function (sessionEvent) {
+            publisher.log('=== Successfully connected and ready to publish messages. ===');
+                                   
+                            
+        });
+        publisher.session.on(solace.SessionEventCode.CONNECT_FAILED_ERROR, function (sessionEvent) {
+            publisher.log('Connection failed to the message router: ' + sessionEvent.infoStr +
+                ' - check correct parameter values and connectivity!');
+        });
+        publisher.session.on(solace.SessionEventCode.DISCONNECTED, function (sessionEvent) {
+            publisher.log('Disconnected.');
+            if (publisher.session !== null) {
+                publisher.session.dispose();
+                publisher.session = null;
+            }
+        });
+        publisher.session.on(solace.SessionEventCode.ACKNOWLEDGED_MESSAGE, function (sessionEvent) {
+            publisher.log('Delivery of message with correlation key = ' +
+                sessionEvent.correlationKey.id + ' confirmed.');
+        });
+        publisher.session.on(solace.SessionEventCode.REJECTED_MESSAGE_ERROR, function (sessionEvent) {
+            publisher.log('Delivery of message with correlation key = ' +
+                sessionEvent.correlationKey.id + ' rejected, info: ' + sessionEvent.infoStr);
+        });
+
+        publisher.connectToSolace();   
+
+    };
+
+    // Actually connects the session triggered when the iframe has been loaded - see in html code
+    publisher.connectToSolace = function () {
+        try {
+            publisher.session.connect();
+        } catch (error) {
+            publisher.log(error.toString());
+        }
+    };
+
+    // Publish one message
+    publisher.publish = function () {
+        if (publisher.session !== null) {
+            var messageText = 'Sample Message';
+            var message = solace.SolclientFactory.createMessage();
+            message.setBinaryAttachment(messageText);
+            message.setDeliveryMode(solace.MessageDeliveryModeType.PERSISTENT);
+            // Define a correlation key object
+            const correlationKey = {
+                name: "MESSAGE_CORRELATIONKEY",
+                id: Date.now()
+            };
+            message.setCorrelationKey(correlationKey);
+            publisher.log('Publishing message "' + messageText + '" to topic "' + publisher.topicName + '/' + correlationKey.id + '"...');
+            message.setDestination(solace.SolclientFactory.createTopicDestination(publisher.topicName + '/' + correlationKey.id));
+
+            try {
+                // Delivery not yet confirmed. See ConfirmedPublish.js
+                publisher.session.send(message);
+                publisher.log('Message sent with correlation key: ' + correlationKey.id);
+            } catch (error) {
+                publisher.log(error.toString());
+            }
+        } else {
+            publisher.log('Cannot publish messages because not connected to Solace message router.');
+        }
+    };
+
+    // Gracefully disconnects from Solace message router
+    publisher.disconnect = function () {
+        publisher.log('Disconnecting from Solace message router...');
+        if (publisher.session !== null) {
+            try {
+                publisher.session.disconnect();
+            } catch (error) {
+                publisher.log(error.toString());
+            }
+        } else {
+            publisher.log('Not connected to Solace message router.');
+        }
+    };
+
+    publisher.clear = function () {
+      publisher.log('Clearing log messages...');
+      document.getElementById('log').value = "";
+    }
+
+    return publisher;
+};

--- a/src/basic-samples/GuaranteedPublisher/GuaranteedPublisher.js
+++ b/src/basic-samples/GuaranteedPublisher/GuaranteedPublisher.js
@@ -44,7 +44,7 @@ var GuaranteedPublisher = function (topicName) {
         logTextArea.scrollTop = logTextArea.scrollHeight;
     };
 
-    publisher.log('\n*** publisher to topic "' + publisher.topicName + '/*" is ready to connect ***');
+    publisher.log('\n*** publisher to topic "' + publisher.topicName + '/{correlation_id}" is ready to connect ***');
 
     // Establishes connection to Solace PubSub+ Event Broker
     publisher.connect = function () {

--- a/src/basic-samples/GuaranteedPublisher/GuaranteedPublisher.js
+++ b/src/basic-samples/GuaranteedPublisher/GuaranteedPublisher.js
@@ -46,7 +46,7 @@ var GuaranteedPublisher = function (topicName) {
 
     publisher.log('\n*** publisher to topic "' + publisher.topicName + '/*" is ready to connect ***');
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     publisher.connect = function () {
         if (publisher.session !== null) {
             publisher.log('Already connected and ready to publish messages.');
@@ -63,12 +63,12 @@ var GuaranteedPublisher = function (topicName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            publisher.log('Cannot connect: please specify all the Solace message router properties.');
+            publisher.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        publisher.log('Connecting to Solace message router using url: ' + hosturl);
+        publisher.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         publisher.log('Client username: ' + username);
-        publisher.log('Solace message router VPN name: ' + vpn);
+        publisher.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             publisher.session = solace.SolclientFactory.createSession({
@@ -130,7 +130,8 @@ var GuaranteedPublisher = function (topicName) {
             var message = solace.SolclientFactory.createMessage();
             message.setBinaryAttachment(messageText);
             message.setDeliveryMode(solace.MessageDeliveryModeType.PERSISTENT);
-            // Define a correlation key object
+            // OPTIONAL: You can set a correlation key on the message and check for the correlation
+            // in the ACKNOWLEDGE_MESSAGE callback. Define a correlation key object
             const correlationKey = {
                 name: "MESSAGE_CORRELATIONKEY",
                 id: Date.now()
@@ -147,13 +148,13 @@ var GuaranteedPublisher = function (topicName) {
                 publisher.log(error.toString());
             }
         } else {
-            publisher.log('Cannot publish messages because not connected to Solace message router.');
+            publisher.log('Cannot publish messages because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     publisher.disconnect = function () {
-        publisher.log('Disconnecting from Solace message router...');
+        publisher.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (publisher.session !== null) {
             try {
                 publisher.session.disconnect();
@@ -161,7 +162,7 @@ var GuaranteedPublisher = function (topicName) {
                 publisher.log(error.toString());
             }
         } else {
-            publisher.log('Not connected to Solace message router.');
+            publisher.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
 

--- a/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.html
+++ b/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+      http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<!--
+    Solace Web Messaging API for JavaScript
+    Persistence with Queues tutorial - Guaranteed Subscriber
+    Demonstrates receiving persistent messages on a queue
+-->
+
+<html lang="en">
+
+  <head>
+    <title>Solace Web Messaging API for JavaScript, Persistence with Queues tutorial - Guaranteed Subscriber</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge;" />
+    <meta charset="utf-8"/>
+
+    <link rel="stylesheet" type="text/css" href="../../resources/css/pure.css"></link>
+    <link rel="stylesheet" type="text/css" href="../../resources/css/samples.css"></link>
+    
+    <!-- Load Solace Web Messaging API for JavaScript -->
+    <script src="../../../lib/solclient-debug.js"></script>
+
+    <!-- Load the Persistence with Queues - Guaranteed Subscriber  -->
+    <script src="GuaranteedSubscriber.js"></script>
+
+    <!-- Execute the PublishSubscribe Topic Subscriber tutorial -->
+    <script>
+      var subscriber = null;
+      window.onload = function () {
+        // Initialize factory with the most recent API defaults
+        var factoryProps = new solace.SolclientFactoryProperties();
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        solace.SolclientFactory.init(factoryProps);
+
+        // enable logging to JavaScript console at WARN level
+        // NOTICE: works only with "solclientjs-debug.js"
+        solace.SolclientFactory.setLogLevel(solace.LogLevel.WARN);
+
+        // create the consumer, specifying name of the queue
+        subscriber = new GuaranteedSubscriber('tutorial/queue', 'solace/samples/js/pers/pub');
+        // assign buttons to the subscriber functions
+        document.getElementById("connect").addEventListener("click", subscriber.connect);
+        document.getElementById("disconnect").addEventListener("click", subscriber.disconnect);
+        document.getElementById("startconsume").addEventListener("click", subscriber.startConsume);
+        document.getElementById("stopconsume").addEventListener("click", subscriber.stopConsume);
+        document.getElementById("clear").addEventListener("click", subscriber.clear);
+      };
+      function iframeloaded(){
+        if (subscriber) {
+            subscriber.connectToSolace();
+        }
+      };
+    </script>
+	<style>
+        .warning {
+            padding: 5px; 
+            border: 1px solid black; 
+            background-color: #ff8;
+        }
+        .ie11 {
+            /* Hide instructions that only apply to IE11/Edge */
+            display: none; 
+        }
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+            .ie11 {
+                /* Show instructions in IE11. If you're trying this sample from the local filesystem,
+                   it's easy to miss the prompt at the bottom of the window. */
+                display: block !important;
+            }
+        }
+	</style>
+  </head>
+
+  <body>
+    <!-- used to prompt selection of client certificate -->
+    <iframe id="iframe" src="" onload="iframeloaded()" hidden></iframe>
+
+    <div class="banner">
+      <div class="banner-interior">
+        <span class="logo">
+          <a href="http://dev.solace.com/">
+            <img src="../../resources/images/solace-logo-white.png"/>
+          </a>
+        </span>
+        <div class="banner-heading">
+          Solace Web Messaging API for JavaScript
+        </div>
+      </div>
+    </div>
+
+    <div class="doc-body">
+      <h2>Persistence with Topics tutorial</h2>
+      <h3>Guaranteed Subscriber</h3>
+      <!--[if IE]>
+          <div class="ie9 warning" style="padding: 5px; border: 1px solid black; background-color: #ff8;">
+              IE9 only: If you are running this sample from the local filesystem, click the "Allow blocked content" button
+              in the popup below to enable JavaScript.
+          </div>
+      <![endif]-->
+      <div class="ie11 warning">
+          IE 11 only: If you are running this sample from the local filesystem, click the "Allow blocked content" button
+          in the popup below to enable JavaScript.
+      </div>
+
+      <form class="pure-form pure-form-aligned">
+        <fieldset>
+
+          <div class="pure-control-group">
+            <label for="hosturl">Solace router host url</label>
+            <input id="hosturl" type="text" placeholder="<protocol://host[:port]>">
+          </div>
+
+          <div class="pure-control-group">
+            <label for="message-vpn">Message-vpn</label>
+            <input id="message-vpn" type="text" placeholder="Message VPN" value="default">
+          </div>
+
+          <div class="pure-control-group">
+            <label for="username">Username</label>
+            <input id="username" type="text" placeholder="Username">
+          </div>
+
+          <div class="pure-control-group">
+            <label for="password">Password</label>
+            <input id="password" type="password" placeholder="Password">
+          </div>
+
+        </fieldset>
+        <div class="box">
+          NOTE: Before you proceed, please ensure that the required queue with appropriate subscription is created on the Broker.
+        </div>
+        <div>
+          <button type="button" class="pure-button pure-button-primary" id="connect">Connect</button>
+          <button type="button" class="pure-button button-error" id="disconnect">Disconnect</button>
+        </p>
+        <p>
+          <button type="button" class="pure-button pure-button-primary" id="startconsume">Consume messages </button>
+          <button type="button" class="pure-button button-error" id="stopconsume">Stop consuming</button>
+          <button type="button" class="pure-button pure-button-secondary right" id="clear">Clear</button>
+        </p>
+        
+        <textarea id="log" rows="20" cols="90" autofocus></textarea>
+        
+      </form>
+
+    </div>
+
+  </body>
+  
+</html>
+

--- a/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.html
+++ b/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.html
@@ -54,7 +54,7 @@
         solace.SolclientFactory.setLogLevel(solace.LogLevel.WARN);
 
         // create the consumer, specifying name of the queue
-        subscriber = new GuaranteedSubscriber('tutorial/queue', 'solace/samples/js/pers/>');
+        subscriber = new GuaranteedSubscriber('tutorial/queue');
         // assign buttons to the subscriber functions
         document.getElementById("connect").addEventListener("click", subscriber.connect);
         document.getElementById("disconnect").addEventListener("click", subscriber.disconnect);

--- a/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.html
+++ b/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.html
@@ -54,7 +54,7 @@
         solace.SolclientFactory.setLogLevel(solace.LogLevel.WARN);
 
         // create the consumer, specifying name of the queue
-        subscriber = new GuaranteedSubscriber('tutorial/queue', 'solace/samples/js/pers/pub');
+        subscriber = new GuaranteedSubscriber('tutorial/queue', 'solace/samples/js/pers/>');
         // assign buttons to the subscriber functions
         document.getElementById("connect").addEventListener("click", subscriber.connect);
         document.getElementById("disconnect").addEventListener("click", subscriber.disconnect);
@@ -144,7 +144,7 @@
 
         </fieldset>
         <div class="box">
-          NOTE: Before you proceed, please ensure that the required queue with appropriate subscription is created on the Broker.
+          NOTE: Before you proceed, please ensure that the required queue with appropriate subscription is created on the message router vpn.
         </div>
         <div>
           <button type="button" class="pure-button pure-button-primary" id="connect">Connect</button>

--- a/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.html
+++ b/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.html
@@ -144,7 +144,8 @@
 
         </fieldset>
         <div class="box">
-          NOTE: Before you proceed, please ensure that the required queue with appropriate subscription is created on the message router vpn.
+          NOTE: Before you proceed, please ensure that the required queue with topic subscription 
+          'solace/samples/js/pers/>' is created on the Solace PubSub+ Event Broker.
         </div>
         <div>
           <button type="button" class="pure-button pure-button-primary" id="connect">Connect</button>

--- a/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.js
+++ b/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.js
@@ -26,14 +26,12 @@
 /*jslint es6 browser devel:true*/
 /*global solace*/
 
-var GuaranteedSubscriber = function (queueName, ) {
+var GuaranteedSubscriber = function (queueName,topicName) {
     'use strict';
-    const API = 'js';
-    const TOPIC_PREFIX = "solace/samples/";  // used as the topic "root"
     var subscriber = {};
     subscriber.session = null;
     subscriber.flow = null;
-    subscriber.topicName = TOPIC_PREFIX + API + '/pers/pub/>';
+    subscriber.topicName = topicName;
     subscriber.queueName = queueName;
     subscriber.consuming = false;
 

--- a/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.js
+++ b/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.js
@@ -47,8 +47,8 @@ var GuaranteedSubscriber = function (queueName) {
     };
 
     subscriber.log('\n*** Consumer to queue "' + subscriber.queueName + '" is ready to connect ***');
-    consumer.log('\n/*********************************************************************' +
-                  '\nNOTE: Ensure that the queue with appropriate subscription is created on the Broker.' +
+    subscriber.log('\n/*********************************************************************' +
+                  '\nNOTE: Ensure that the queue with an appropriate subscription is created on the Broker.' +
                   '\n/********************************************************************/')
 
     // Establishes connection to Solace PubSub+ Event Broker
@@ -138,7 +138,7 @@ var GuaranteedSubscriber = function (queueName) {
                     subscriber.messageSubscriber.on(solace.MessageConsumerEventName.CONNECT_FAILED_ERROR, function () {
                         subscriber.consuming = false;
                         subscriber.log('=== Error: the message subscriber could not bind to queue "' + subscriber.queueName +
-                            '" ===\n   Ensure this queue exists on the message router vpn');
+                            '" ===\n   Ensure this queue exists on the Solace PubSub+ Event Broker');
                     });
                     subscriber.messageSubscriber.on(solace.MessageConsumerEventName.DOWN, function () {
                         subscriber.consuming = false;

--- a/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.js
+++ b/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.js
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Solace Web Messaging API for JavaScript
+ * Receiving Guaranteed messages on a Topic tutorial - Guaranteed Subscriber
+ * Demonstrates receiving persistent messages on a topic
+ */
+
+/*jslint es6 browser devel:true*/
+/*global solace*/
+
+var GuaranteedSubscriber = function (queueName, ) {
+    'use strict';
+    const API = 'js';
+    const TOPIC_PREFIX = "solace/samples/";  // used as the topic "root"
+    var subscriber = {};
+    subscriber.session = null;
+    subscriber.flow = null;
+    subscriber.topicName = TOPIC_PREFIX + API + '/pers/pub/>';
+    subscriber.queueName = queueName;
+    subscriber.consuming = false;
+
+    // Logger
+    subscriber.log = function (line) {
+        var now = new Date();
+        var time = [('0' + now.getHours()).slice(-2), ('0' + now.getMinutes()).slice(-2),
+            ('0' + now.getSeconds()).slice(-2)];
+        var timestamp = '[' + time.join(':') + '] ';
+        console.log(timestamp + line);
+        var logTextArea = document.getElementById('log');
+        logTextArea.value += timestamp + line + '\n';
+        logTextArea.scrollTop = logTextArea.scrollHeight;
+    };
+
+    subscriber.log('\n*** Consumer to queue "' + subscriber.queueName + '" is ready to connect ***');
+
+    // Establishes connection to Solace message router
+    subscriber.connect = function () {
+        if (subscriber.session !== null) {
+            subscriber.log('Already connected and ready to consume messages.');
+            return;
+        }
+        var hosturl = document.getElementById('hosturl').value;
+        // check for valid protocols
+        if (hosturl.lastIndexOf('ws://', 0) !== 0 && hosturl.lastIndexOf('wss://', 0) !== 0 &&
+            hosturl.lastIndexOf('http://', 0) !== 0 && hosturl.lastIndexOf('https://', 0) !== 0) {
+            subscriber.log('Invalid protocol - please use one of ws://, wss://, http://, https://');
+            return;
+        }
+        var username = document.getElementById('username').value;
+        var pass = document.getElementById('password').value;
+        var vpn = document.getElementById('message-vpn').value;
+        if (!hosturl || !username || !pass || !vpn) {
+            subscriber.log('Cannot connect: please specify all the Solace message router properties.');
+            return;
+        }
+        subscriber.log('Connecting to Solace message router using url: ' + hosturl);
+        subscriber.log('Client username: ' + username);
+        subscriber.log('Solace message router VPN name: ' + vpn);
+        // create session
+        try {
+            subscriber.session = solace.SolclientFactory.createSession({
+                // solace.SessionProperties
+                url:      hosturl,
+                vpnName:  vpn,
+                userName: username,
+                password: pass,
+            });
+        } catch (error) {
+            subscriber.log(error.toString());
+        }
+
+        // define session event listeners
+        subscriber.session.on(solace.SessionEventCode.UP_NOTICE, function (sessionEvent) {
+            subscriber.log('=== Successfully connected and ready to start the message subscriber. ===');
+        });
+        subscriber.session.on(solace.SessionEventCode.CONNECT_FAILED_ERROR, function (sessionEvent) {
+            subscriber.log('Connection failed to the message router: ' + sessionEvent.infoStr +
+                ' - check correct parameter values and connectivity!');
+        });
+        subscriber.session.on(solace.SessionEventCode.DISCONNECTED, function (sessionEvent) {
+            subscriber.log('Disconnected.');
+            subscriber.consuming = false;
+            if (subscriber.session !== null) {
+                subscriber.session.dispose();
+                subscriber.session = null;
+            }
+        });
+
+        subscriber.connectToSolace();   
+    };
+
+    // Actually connects the session triggered when the iframe has been loaded - see in html code
+    subscriber.connectToSolace = function () {
+        try {
+            subscriber.session.connect();
+        } catch (error) {
+            subscriber.log(error.toString());
+        }
+    };
+
+    // Starts consuming from a queue on Solace message router
+    subscriber.startConsume = function () {
+        if (subscriber.session !== null) {
+            if (subscriber.consuming) {
+                subscriber.log('Already started subscriber for queue "' + subscriber.queueName + '" and ready to receive messages.');
+            } else {
+                subscriber.log('Starting subscriber for queue: ' + subscriber.queueName);
+                try {
+                    // Create a message subscriber
+                    subscriber.messagesubscriber = subscriber.session.createMessageConsumer({
+                        // solace.MessageConsumerProperties
+                        queueDescriptor: { name: subscriber.queueName, type: solace.QueueType.QUEUE },
+                        acknowledgeMode: solace.MessageConsumerAcknowledgeMode.CLIENT, // Enabling Client ack
+                    });
+                    // Define message subscriber event listeners
+                    subscriber.messagesubscriber.on(solace.MessageConsumerEventName.UP, function () {
+                        subscriber.consuming = true;
+                        subscriber.log('=== Ready to receive messages. ===');
+                    });
+                    subscriber.messagesubscriber.on(solace.MessageConsumerEventName.CONNECT_FAILED_ERROR, function () {
+                        subscriber.consuming = false;
+                        subscriber.log('=== Error: the message subscriber could not bind to queue "' + subscriber.queueName +
+                            '" ===\n   Ensure this queue exists on the message router vpn');
+                    });
+                    subscriber.messagesubscriber.on(solace.MessageConsumerEventName.DOWN, function () {
+                        subscriber.consuming = false;
+                        subscriber.log('=== The message subscriber is now down ===');
+                    });
+                    subscriber.messagesubscriber.on(solace.MessageConsumerEventName.DOWN_ERROR, function () {
+                        subscriber.consuming = false;
+                        subscriber.log('=== An error happened, the message subscriber is down ===');
+                    });
+                    // Define message received event listener
+                    subscriber.messagesubscriber.on(solace.MessageConsumerEventName.MESSAGE, function (message) {
+                        subscriber.log('Received message: "' + message.getBinaryAttachment() + '",' +
+                            ' details:\n' + message.dump());
+                        // Need to explicitly ack otherwise it will not be deleted from the message router
+                        message.acknowledge();
+                    });
+                    // Connect the message subscriber
+                    subscriber.messagesubscriber.connect();
+                } catch (error) {
+                    subscriber.log(error.toString());
+                }
+            }
+        } else {
+            subscriber.log('Cannot start the queue subscriber because not connected to Solace message router.');
+        }
+    };
+
+    // Disconnects the subscriber from queue on Solace message router
+    subscriber.stopConsume = function () {
+        if (subscriber.session !== null) {
+            if (subscriber.consuming) {
+                subscriber.consuming = false;
+                subscriber.log('Disconnecting consumption from queue: ' + subscriber.queueName);
+                try {
+                    subscriber.messagesubscriber.disconnect();
+                    subscriber.messagesubscriber.dispose();
+                } catch (error) {
+                    subscriber.log(error.toString());
+                }
+            } else {
+                subscriber.log('Cannot disconnect the subscriber because it is not connected to queue "' +
+                    subscriber.queueName + '"');
+            }
+        } else {
+            subscriber.log('Cannot disconnect the subscriber because not connected to Solace message router.');
+        }
+    };
+
+    // Gracefully disconnects from Solace message router
+    subscriber.disconnect = function () {
+        subscriber.log('Disconnecting from Solace message router...');
+        if (subscriber.session !== null) {
+            try {
+                subscriber.session.disconnect();
+            } catch (error) {
+                subscriber.log(error.toString());
+            }
+        } else {
+            subscriber.log('Not connected to Solace message router.');
+        }
+    };
+
+    subscriber.clear = function () {
+      subscriber.log('Clearing log messages...');
+      document.getElementById('log').value = "";
+    }
+
+    return subscriber;
+};
+

--- a/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.js
+++ b/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.js
@@ -20,18 +20,17 @@
 /**
  * Solace Web Messaging API for JavaScript
  * Receiving Guaranteed messages on a Topic tutorial - Guaranteed Subscriber
- * Demonstrates receiving persistent messages on a topic
+ * Demonstrates receiving persistent messages on a subscribed topic
  */
 
 /*jslint es6 browser devel:true*/
 /*global solace*/
 
-var GuaranteedSubscriber = function (queueName,topicName) {
+var GuaranteedSubscriber = function (queueName) {
     'use strict';
     var subscriber = {};
     subscriber.session = null;
     subscriber.flow = null;
-    subscriber.topicName = topicName;
     subscriber.queueName = queueName;
     subscriber.consuming = false;
 
@@ -48,8 +47,11 @@ var GuaranteedSubscriber = function (queueName,topicName) {
     };
 
     subscriber.log('\n*** Consumer to queue "' + subscriber.queueName + '" is ready to connect ***');
+    consumer.log('\n/*********************************************************************' +
+                  '\nNOTE: Ensure that the queue with appropriate subscription is created on the Broker.' +
+                  '\n/********************************************************************/')
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     subscriber.connect = function () {
         if (subscriber.session !== null) {
             subscriber.log('Already connected and ready to consume messages.');
@@ -66,12 +68,12 @@ var GuaranteedSubscriber = function (queueName,topicName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            subscriber.log('Cannot connect: please specify all the Solace message router properties.');
+            subscriber.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        subscriber.log('Connecting to Solace message router using url: ' + hosturl);
+        subscriber.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         subscriber.log('Client username: ' + username);
-        subscriber.log('Solace message router VPN name: ' + vpn);
+        subscriber.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             subscriber.session = solace.SolclientFactory.createSession({
@@ -114,7 +116,7 @@ var GuaranteedSubscriber = function (queueName,topicName) {
         }
     };
 
-    // Starts consuming from a queue on Solace message router
+    // Starts consuming from a queue on Solace PubSub+ Event Broker
     subscriber.startConsume = function () {
         if (subscriber.session !== null) {
             if (subscriber.consuming) {
@@ -123,56 +125,56 @@ var GuaranteedSubscriber = function (queueName,topicName) {
                 subscriber.log('Starting subscriber for queue: ' + subscriber.queueName);
                 try {
                     // Create a message subscriber
-                    subscriber.messagesubscriber = subscriber.session.createMessageConsumer({
+                    subscriber.messageSubscriber = subscriber.session.createMessageConsumer({
                         // solace.MessageConsumerProperties
                         queueDescriptor: { name: subscriber.queueName, type: solace.QueueType.QUEUE },
                         acknowledgeMode: solace.MessageConsumerAcknowledgeMode.CLIENT, // Enabling Client ack
                     });
                     // Define message subscriber event listeners
-                    subscriber.messagesubscriber.on(solace.MessageConsumerEventName.UP, function () {
+                    subscriber.messageSubscriber.on(solace.MessageConsumerEventName.UP, function () {
                         subscriber.consuming = true;
                         subscriber.log('=== Ready to receive messages. ===');
                     });
-                    subscriber.messagesubscriber.on(solace.MessageConsumerEventName.CONNECT_FAILED_ERROR, function () {
+                    subscriber.messageSubscriber.on(solace.MessageConsumerEventName.CONNECT_FAILED_ERROR, function () {
                         subscriber.consuming = false;
                         subscriber.log('=== Error: the message subscriber could not bind to queue "' + subscriber.queueName +
                             '" ===\n   Ensure this queue exists on the message router vpn');
                     });
-                    subscriber.messagesubscriber.on(solace.MessageConsumerEventName.DOWN, function () {
+                    subscriber.messageSubscriber.on(solace.MessageConsumerEventName.DOWN, function () {
                         subscriber.consuming = false;
                         subscriber.log('=== The message subscriber is now down ===');
                     });
-                    subscriber.messagesubscriber.on(solace.MessageConsumerEventName.DOWN_ERROR, function () {
+                    subscriber.messageSubscriber.on(solace.MessageConsumerEventName.DOWN_ERROR, function () {
                         subscriber.consuming = false;
                         subscriber.log('=== An error happened, the message subscriber is down ===');
                     });
                     // Define message received event listener
-                    subscriber.messagesubscriber.on(solace.MessageConsumerEventName.MESSAGE, function (message) {
+                    subscriber.messageSubscriber.on(solace.MessageConsumerEventName.MESSAGE, function (message) {
                         subscriber.log('Received message: "' + message.getBinaryAttachment() + '",' +
                             ' details:\n' + message.dump());
                         // Need to explicitly ack otherwise it will not be deleted from the message router
                         message.acknowledge();
                     });
                     // Connect the message subscriber
-                    subscriber.messagesubscriber.connect();
+                    subscriber.messageSubscriber.connect();
                 } catch (error) {
                     subscriber.log(error.toString());
                 }
             }
         } else {
-            subscriber.log('Cannot start the queue subscriber because not connected to Solace message router.');
+            subscriber.log('Cannot start the queue subscriber because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Disconnects the subscriber from queue on Solace message router
+    // Disconnects the subscriber from queue on Solace PubSub+ Event Broker
     subscriber.stopConsume = function () {
         if (subscriber.session !== null) {
             if (subscriber.consuming) {
                 subscriber.consuming = false;
                 subscriber.log('Disconnecting consumption from queue: ' + subscriber.queueName);
                 try {
-                    subscriber.messagesubscriber.disconnect();
-                    subscriber.messagesubscriber.dispose();
+                    subscriber.messageSubscriber.disconnect();
+                    subscriber.messageSubscriber.dispose();
                 } catch (error) {
                     subscriber.log(error.toString());
                 }
@@ -181,13 +183,13 @@ var GuaranteedSubscriber = function (queueName,topicName) {
                     subscriber.queueName + '"');
             }
         } else {
-            subscriber.log('Cannot disconnect the subscriber because not connected to Solace message router.');
+            subscriber.log('Cannot disconnect the subscriber because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     subscriber.disconnect = function () {
-        subscriber.log('Disconnecting from Solace message router...');
+        subscriber.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (subscriber.session !== null) {
             try {
                 subscriber.session.disconnect();
@@ -195,7 +197,7 @@ var GuaranteedSubscriber = function (queueName,topicName) {
                 subscriber.log(error.toString());
             }
         } else {
-            subscriber.log('Not connected to Solace message router.');
+            subscriber.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
 

--- a/src/basic-samples/TopicPublisher/TopicPublisher.js
+++ b/src/basic-samples/TopicPublisher/TopicPublisher.js
@@ -46,7 +46,7 @@ var TopicPublisher = function (topicName) {
 
     publisher.log('\n*** Publisher to topic "' + publisher.topicName + '" is ready to connect ***');
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     publisher.connect = function () {
         // extract params
         if (publisher.session !== null) {
@@ -64,12 +64,12 @@ var TopicPublisher = function (topicName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            publisher.log('Cannot connect: please specify all the Solace message router properties.');
+            publisher.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        publisher.log('Connecting to Solace message router using url: ' + hosturl);
+        publisher.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         publisher.log('Client username: ' + username);
-        publisher.log('Solace message router VPN name: ' + vpn);
+        publisher.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             publisher.session = solace.SolclientFactory.createSession({
@@ -127,13 +127,13 @@ var TopicPublisher = function (topicName) {
                 publisher.log(error.toString());
             }
         } else {
-            publisher.log('Cannot publish because not connected to Solace message router.');
+            publisher.log('Cannot publish because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     publisher.disconnect = function () {
-        publisher.log('Disconnecting from Solace message router...');
+        publisher.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (publisher.session !== null) {
             try {
                 publisher.session.disconnect();
@@ -141,7 +141,7 @@ var TopicPublisher = function (topicName) {
                 publisher.log(error.toString());
             }
         } else {
-            publisher.log('Not connected to Solace message router.');
+            publisher.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
 

--- a/src/basic-samples/TopicSubscriber/TopicSubscriber.js
+++ b/src/basic-samples/TopicSubscriber/TopicSubscriber.js
@@ -65,12 +65,12 @@ var TopicSubscriber = function (topicName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            subscriber.log('Cannot connect: please specify all the Solace message router properties.');
+            subscriber.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        subscriber.log('Connecting to Solace message router using url: ' + hosturl);
+        subscriber.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         subscriber.log('Client username: ' + username);
-        subscriber.log('Solace message router VPN name: ' + vpn);
+        subscriber.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             subscriber.session = solace.SolclientFactory.createSession({
@@ -134,7 +134,7 @@ var TopicSubscriber = function (topicName) {
         }
     };
 
-    // Subscribes to topic on Solace message router
+    // Subscribes to topic on Solace PubSub+ Event Broker
     subscriber.subscribe = function () {
         if (subscriber.session !== null) {
             if (subscriber.subscribed) {
@@ -154,11 +154,11 @@ var TopicSubscriber = function (topicName) {
                 }
             }
         } else {
-            subscriber.log('Cannot subscribe because not connected to Solace message router.');
+            subscriber.log('Cannot subscribe because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Unsubscribes from topic on Solace message router
+    // Unsubscribes from topic on Solace PubSub+ Event Broker
     subscriber.unsubscribe = function () {
         if (subscriber.session !== null) {
             if (subscriber.subscribed) {
@@ -178,13 +178,13 @@ var TopicSubscriber = function (topicName) {
                     + subscriber.topicName + '"');
             }
         } else {
-            subscriber.log('Cannot unsubscribe because not connected to Solace message router.');
+            subscriber.log('Cannot unsubscribe because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     subscriber.disconnect = function () {
-        subscriber.log('Disconnecting from Solace message router...');
+        subscriber.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (subscriber.session !== null) {
             try {
                 subscriber.session.disconnect();
@@ -192,7 +192,7 @@ var TopicSubscriber = function (topicName) {
                 subscriber.log(error.toString());
             }
         } else {
-            subscriber.log('Not connected to Solace message router.');
+            subscriber.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
 

--- a/src/features/ActiveConsumerIndication/ActiveConsumerIndication.js
+++ b/src/features/ActiveConsumerIndication/ActiveConsumerIndication.js
@@ -64,7 +64,7 @@ var QueueConsumer = function (queueName) {
 
     sample.log('\n*** Consumer to queue "' + sample.queueName + '" is ready to connect ***');
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     sample.connect = function (argv) {
         if (sample.session !== null) {
             sample.log('Already connected and ready to consume messages.');
@@ -81,12 +81,12 @@ var QueueConsumer = function (queueName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            sample.log('Cannot connect: please specify all the Solace message router properties.');
+            sample.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        sample.log('Connecting to Solace message router using url: ' + hosturl);
+        sample.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         sample.log('Client username: ' + username);
-        sample.log('Solace message router VPN name: ' + vpn);
+        sample.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             sample.session = solace.SolclientFactory.createSession({
@@ -129,7 +129,7 @@ var QueueConsumer = function (queueName) {
         }
     };
 
-    // Starts consuming from a queue on Solace message router
+    // Starts consuming from a queue on Solace PubSub+ Event Broker
     sample.startConsume = function () {
         if (sample.session !== null) {
             if (sample.consuming) {
@@ -151,7 +151,7 @@ var QueueConsumer = function (queueName) {
                 }
             }
         } else {
-            sample.log('Cannot start the queue consumer because not connected to Solace message router.');
+            sample.log('Cannot start the queue consumer because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
@@ -205,9 +205,9 @@ var QueueConsumer = function (queueName) {
         return messageConsumer;
     }
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     sample.disconnect = function () {
-        sample.log('Disconnecting from Solace message router...');
+        sample.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (sample.session !== null) {
             try {
                 sample.session.disconnect();
@@ -215,7 +215,7 @@ var QueueConsumer = function (queueName) {
                 sample.log(error.toString());
             }
         } else {
-            sample.log('Not connected to Solace message router.');
+            sample.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
 

--- a/src/features/ActiveConsumerIndication/ActiveConsumerIndication.js
+++ b/src/features/ActiveConsumerIndication/ActiveConsumerIndication.js
@@ -170,7 +170,7 @@ var QueueConsumer = function (queueName) {
         messageConsumer.on(solace.MessageConsumerEventName.CONNECT_FAILED_ERROR, function () {
             sample.consuming = false;
             sample.log('=== ' + messageConsumerName + ': Error: the message consumer could not bind to queue "' +
-                sample.queueName + '" ===\n   Ensure this queue exists on the message router vpn');
+                sample.queueName + '" ===\n   Ensure this queue exists on the Solace PubSub+ Event Broker');
         });
         messageConsumer.on(solace.MessageConsumerEventName.DOWN, function () {
             sample.consuming = false;

--- a/src/features/DTEConsumer/DTEConsumer.js
+++ b/src/features/DTEConsumer/DTEConsumer.js
@@ -57,7 +57,7 @@ var DTEConsumer = function (topicEndpointName, topicName) {
 
     consumer.log('\n*** Consumer to DTE "' + consumer.topicEndpointName + '" is ready to connect ***');
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     consumer.connect = function () {
         if (consumer.session !== null) {
             consumer.log('Already connected and ready to consume messages.');
@@ -74,12 +74,12 @@ var DTEConsumer = function (topicEndpointName, topicName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            consumer.log('Cannot connect: please specify all the Solace message router properties.');
+            consumer.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        consumer.log('Connecting to Solace message router using url: ' + hosturl);
+        consumer.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         consumer.log('Client username: ' + username);
-        consumer.log('Solace message router VPN name: ' + vpn);
+        consumer.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             consumer.session = solace.SolclientFactory.createSession({
@@ -122,7 +122,7 @@ var DTEConsumer = function (topicEndpointName, topicName) {
         }
     };
 
-    // Starts consuming from a Durable Topic Endpoint (DTE) on Solace message router
+    // Starts consuming from a Durable Topic Endpoint (DTE) on Solace PubSub+ Event Broker
     consumer.startConsume = function () {
         if (consumer.session !== null) {
             if (consumer.consuming) {
@@ -166,11 +166,11 @@ var DTEConsumer = function (topicEndpointName, topicName) {
                 }
             }
         } else {
-            consumer.log('Cannot start the DTE consumer because not connected to Solace message router.');
+            consumer.log('Cannot start the DTE consumer because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Disconnects the consumer from DTE on Solace message router
+    // Disconnects the consumer from DTE on Solace PubSub+ Event Broker
     consumer.stopConsume = function () {
         if (consumer.session !== null) {
             if (consumer.consuming) {
@@ -187,13 +187,13 @@ var DTEConsumer = function (topicEndpointName, topicName) {
                     consumer.topicEndpointName + '"');
             }
         } else {
-            consumer.log('Cannot disconnect the consumer because not connected to Solace message router.');
+            consumer.log('Cannot disconnect the consumer because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     consumer.disconnect = function () {
-        consumer.log('Disconnecting from Solace message router...');
+        consumer.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (consumer.session !== null) {
             try {
                 consumer.session.disconnect();
@@ -201,7 +201,7 @@ var DTEConsumer = function (topicEndpointName, topicName) {
                 consumer.log(error.toString());
             }
         } else {
-            consumer.log('Not connected to Solace message router.');
+            consumer.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
 

--- a/src/features/DTEConsumer/DTEConsumer.js
+++ b/src/features/DTEConsumer/DTEConsumer.js
@@ -148,7 +148,7 @@ var DTEConsumer = function (topicEndpointName, topicName) {
                         consumer.consuming = false;
                         consumer.log('=== Error: the message consumer could not bind to DTE "' +
                             consumer.topicEndpointName +
-                            '" ===\n   Ensure this Durable Topic Endpoint exists on the message router vpn');
+                            '" ===\n   Ensure this Durable Topic Endpoint exists on the Solace PubSub+ Event Broker');
                     });
                     consumer.messageConsumer.on(solace.MessageConsumerEventName.DOWN, function () {
                         consumer.consuming = false;

--- a/src/features/EventMonitor/EventMonitor.js
+++ b/src/features/EventMonitor/EventMonitor.js
@@ -56,7 +56,7 @@ var EventSubscriber = function () {
 
     subscriber.log('\n*** Event Monitor is ready to connect ***');
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     subscriber.connect = function () {
         if (subscriber.session !== null) {
             subscriber.log('Already connected and ready to subscribe to events.');
@@ -73,12 +73,12 @@ var EventSubscriber = function () {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            subscriber.log('Cannot connect: please specify all the Solace message router properties.');
+            subscriber.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        subscriber.log('Connecting to Solace message router using url: ' + hosturl);
+        subscriber.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         subscriber.log('Client username: ' + username);
-        subscriber.log('Solace message router VPN name: ' + vpn);
+        subscriber.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             subscriber.session = solace.SolclientFactory.createSession({
@@ -138,7 +138,7 @@ var EventSubscriber = function () {
         }
     };
 
-    // Subscribes to topic on Solace message router
+    // Subscribes to topic on Solace PubSub+ Event Broker
     subscriber.subscribe = function () {
         if (subscriber.session !== null) {
             if (subscriber.subscribed) {
@@ -159,11 +159,11 @@ var EventSubscriber = function () {
                 }
             }
         } else {
-            subscriber.log('Cannot subscribe because not connected to Solace message router.');
+            subscriber.log('Cannot subscribe because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Unsubscribes from topic on Solace message router
+    // Unsubscribes from topic on Solace PubSub+ Event Broker
     subscriber.unsubscribe = function () {
         if (subscriber.session !== null) {
             if (subscriber.subscribed) {
@@ -182,13 +182,13 @@ var EventSubscriber = function () {
                 subscriber.log('Cannot unsubscribe because not subscribed to the topic "' + subscriber.topicName + '"');
             }
         } else {
-            subscriber.log('Cannot unsubscribe because not connected to Solace message router.');
+            subscriber.log('Cannot unsubscribe because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     subscriber.disconnect = function () {
-        subscriber.log('Disconnecting from Solace message router...');
+        subscriber.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (subscriber.session !== null) {
             try {
                 subscriber.session.disconnect();
@@ -196,7 +196,7 @@ var EventSubscriber = function () {
                 subscriber.log(error.toString());
             }
         } else {
-            subscriber.log('Not connected to Solace message router.');
+            subscriber.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
 

--- a/src/features/GuaranteedReplier/GuaranteedReplier.js
+++ b/src/features/GuaranteedReplier/GuaranteedReplier.js
@@ -57,7 +57,7 @@ var GuaranteedReplier = function (requestTopicName) {
 
     replier.log('\n*** replier to request topic "' + replier.requestTopicName + '" is ready to connect ***');
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     replier.connect = function () {
         if (replier.session !== null) {
             replier.log('Already connected and ready to subscribe to request topic.');
@@ -74,12 +74,12 @@ var GuaranteedReplier = function (requestTopicName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            replier.log('Cannot connect: please specify all the Solace message router properties.');
+            replier.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        replier.log('Connecting to Solace message router using url: ' + hosturl);
+        replier.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         replier.log('Client username: ' + username);
-        replier.log('Solace message router VPN name: ' + vpn);
+        replier.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             replier.session = solace.SolclientFactory.createSession({
@@ -123,7 +123,7 @@ var GuaranteedReplier = function (requestTopicName) {
         }
     };
 
-    // Subscribes to temporary topic endpoint on Solace message router
+    // Subscribes to temporary topic endpoint on Solace PubSub+ Event Broker
     replier.startService = function () {
         if (replier.session !== null) {
             if (replier.active) {
@@ -149,7 +149,7 @@ var GuaranteedReplier = function (requestTopicName) {
                 }
             }
         } else {
-            replier.log('Cannot start replier because not connected to Solace message router.');
+            replier.log('Cannot start replier because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
@@ -171,11 +171,11 @@ var GuaranteedReplier = function (requestTopicName) {
             }
             replier.log('Replied.');
         } else {
-            replier.log('Cannot reply: not connected to Solace message router.');
+            replier.log('Cannot reply: not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Stops the replier service on Solace message router
+    // Stops the replier service on Solace PubSub+ Event Broker
     replier.stopService = function () {
         if (replier.session !== null) {
             if (replier.active) {
@@ -192,13 +192,13 @@ var GuaranteedReplier = function (requestTopicName) {
                     replier.requestTopicName + '"');
             }
         } else {
-            replier.log('Cannot stop replier because not connected to Solace message router.');
+            replier.log('Cannot stop replier because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     replier.disconnect = function () {
-        replier.log('Disconnecting from Solace message router...');
+        replier.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (replier.session !== null) {
             try {
                 replier.session.disconnect();
@@ -208,7 +208,7 @@ var GuaranteedReplier = function (requestTopicName) {
                 replier.log(error.toString());
             }
         } else {
-            replier.log('Not connected to Solace message router.');
+            replier.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
 

--- a/src/features/GuaranteedRequestor/GuaranteedRequestor.js
+++ b/src/features/GuaranteedRequestor/GuaranteedRequestor.js
@@ -56,7 +56,7 @@ var GuaranteedRequestor = function (requestTopicName) {
 
     requestor.log('\n*** requestor to topic "' + requestor.requestTopicName + '" is ready to connect ***');
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     requestor.connect = function () {
         if (requestor.session !== null) {
             requestor.log('Already connected and ready to send requests.');
@@ -73,12 +73,12 @@ var GuaranteedRequestor = function (requestTopicName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            requestor.log('Cannot connect: please specify all the Solace message router properties.');
+            requestor.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        requestor.log('Connecting to Solace message router using url: ' + hosturl);
+        requestor.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         requestor.log('Client username: ' + username);
-        requestor.log('Solace message router VPN name: ' + vpn);
+        requestor.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             requestor.session = solace.SolclientFactory.createSession({
@@ -152,13 +152,13 @@ var GuaranteedRequestor = function (requestTopicName) {
             });
             replyMessageConsumer.connect();
         } else {
-            requestor.log('Cannot send request because not connected to Solace message router.');
+            requestor.log('Cannot send request because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     requestor.disconnect = function () {
-        requestor.log('Disconnecting from Solace message router...');
+        requestor.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (requestor.session !== null) {
             try {
                 requestor.session.disconnect();
@@ -166,7 +166,7 @@ var GuaranteedRequestor = function (requestTopicName) {
                 requestor.log(error.toString());
             }
         } else {
-            requestor.log('Not connected to Solace message router.');
+            requestor.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
 

--- a/src/features/MessageReplay/MessageReplay.js
+++ b/src/features/MessageReplay/MessageReplay.js
@@ -50,7 +50,7 @@ var QueueConsumer = function (queueName) {
 
     consumer.log('\n*** Consumer to queue "' + consumer.queueName + '" is ready to connect ***');
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     consumer.connect = function () {
         if (consumer.session !== null) {
             consumer.log('Already connected.');
@@ -67,12 +67,12 @@ var QueueConsumer = function (queueName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            consumer.log('Cannot connect: please specify all the Solace message router properties.');
+            consumer.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        consumer.log('Connecting to Solace message router using url: ' + hosturl);
+        consumer.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         consumer.log('Client username: ' + username);
-        consumer.log('Solace message router VPN name: ' + vpn);
+        consumer.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             consumer.session = solace.SolclientFactory.createSession({
@@ -123,7 +123,7 @@ var QueueConsumer = function (queueName) {
         }
     };
 
-    // Starts message replay from a queue on Solace message router
+    // Starts message replay from a queue on Solace PubSub+ Event Broker
     consumer.startReplay = function () {
         if (consumer.session !== null) {
             if (consumer.consuming) {
@@ -147,7 +147,7 @@ var QueueConsumer = function (queueName) {
                 consumer.createFlow();
             }
         } else {
-            consumer.log('Cannot start the queue consumer because not connected to Solace message router.');
+            consumer.log('Cannot start the queue consumer because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
@@ -216,7 +216,7 @@ var QueueConsumer = function (queueName) {
         }
     };
 
-    // Disconnects the consumer from queue on Solace message router
+    // Disconnects the consumer from queue on Solace PubSub+ Event Broker
     consumer.stopConsume = function () {
         if (consumer.session !== null) {
             if (consumer.consuming) {
@@ -233,13 +233,13 @@ var QueueConsumer = function (queueName) {
                     consumer.queueName + '"');
             }
         } else {
-            consumer.log('Cannot disconnect the consumer because not connected to Solace message router.');
+            consumer.log('Cannot disconnect the consumer because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     consumer.disconnect = function () {
-        consumer.log('Disconnecting from Solace message router...');
+        consumer.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (consumer.session !== null) {
             try {
                 consumer.session.disconnect();
@@ -247,7 +247,7 @@ var QueueConsumer = function (queueName) {
                 consumer.log(error.toString());
             }
         } else {
-            consumer.log('Not connected to Solace message router.');
+            consumer.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
 

--- a/src/features/MessageReplay/MessageReplay.js
+++ b/src/features/MessageReplay/MessageReplay.js
@@ -170,7 +170,7 @@ var QueueConsumer = function (queueName) {
                 consumer.log('\n=== Error: the message consumer could not bind to queue "' + consumer.queueName +
 			"' ===\nError message: " + error.message +
                         "\nEnsure that:" +
-                        "\n   - The queue exists on the message router vpn" +
+                        "\n   - The queue exists on the Solace PubSub+ Event Broker" +
 			"\n   - You have created the replay log.");
             });
             consumer.messageConsumer.on(solace.MessageConsumerEventName.DOWN, function () {

--- a/src/features/NoLocalPubSub/NoLocalPubSub.js
+++ b/src/features/NoLocalPubSub/NoLocalPubSub.js
@@ -62,7 +62,7 @@ var NoLocalPubSub = function (topicName) {
 
     sample.log('\n*** NoLocalPubSub is ready to connect ***');
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     sample.connect = function () {
         if (sample.session1 !== null) {
             sample.log('Already connected and ready to start demo.');
@@ -79,12 +79,12 @@ var NoLocalPubSub = function (topicName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            sample.log('Cannot connect: please specify all the Solace message router properties.');
+            sample.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        sample.log('Connecting to Solace message router using url: ' + hosturl);
+        sample.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         sample.log('Client username: ' + username);
-        sample.log('Solace message router VPN name: ' + vpn);
+        sample.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         sample.sessionProperties = new solace.SessionProperties({
             url:      hosturl,
             vpnName:  vpn,
@@ -226,9 +226,9 @@ var NoLocalPubSub = function (topicName) {
         fromSession.send(message);
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     sample.disconnect = function () {
-        sample.log('Disconnecting both sessions from Solace message router...');
+        sample.log('Disconnecting both sessions from Solace PubSub+ Event Broker...');
         [sample.session1, sample.session2].forEach(function(session) {
             if (session && session !== null) {
                 try {

--- a/src/features/QueueConsumer/QueueConsumer.html
+++ b/src/features/QueueConsumer/QueueConsumer.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+      http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<!--
+    Solace Web Messaging API for JavaScript
+    Persistence with Queues tutorial - Queue Consumer
+    Demonstrates sending persistent messages to a queue
+-->
+
+<html lang="en">
+
+  <head>
+    <title>Solace Web Messaging API for JavaScript, Persistence with Queues tutorial - Queue Consumer</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge;" />
+    <meta charset="utf-8"/>
+
+    <link rel="stylesheet" type="text/css" href="../../resources/css/pure.css"></link>
+    <link rel="stylesheet" type="text/css" href="../../resources/css/samples.css"></link>
+    
+    <!-- Load Solace Web Messaging API for JavaScript -->
+    <script src="../../../lib/solclient-debug.js"></script>
+
+    <!-- Load the Persistence with Queues - Queue Consumer  -->
+    <script src="QueueConsumer.js"></script>
+
+    <!-- Execute the PublishSubscribe Topic Subscriber tutorial -->
+    <script>
+      var subscriber = null;
+      window.onload = function () {
+        // Initialize factory with the most recent API defaults
+        var factoryProps = new solace.SolclientFactoryProperties();
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        solace.SolclientFactory.init(factoryProps);
+
+        // enable logging to JavaScript console at WARN level
+        // NOTICE: works only with "solclientjs-debug.js"
+        solace.SolclientFactory.setLogLevel(solace.LogLevel.WARN);
+
+        // create the consumer, specifying name of the queue
+        subscriber = new QueueConsumer('tutorial/queue');
+        // assign buttons to the subscriber functions
+        document.getElementById("connect").addEventListener("click", subscriber.connect);
+        document.getElementById("disconnect").addEventListener("click", subscriber.disconnect);
+        document.getElementById("startconsume").addEventListener("click", subscriber.startConsume);
+        document.getElementById("stopconsume").addEventListener("click", subscriber.stopConsume);
+        document.getElementById("clear").addEventListener("click", subscriber.clear);
+      };
+      function iframeloaded(){
+        if (subscriber) {
+            subscriber.connectToSolace();
+        }
+      };
+    </script>
+	<style>
+        .warning {
+            padding: 5px; 
+            border: 1px solid black; 
+            background-color: #ff8;
+        }
+        .ie11 {
+            /* Hide instructions that only apply to IE11/Edge */
+            display: none; 
+        }
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+            .ie11 {
+                /* Show instructions in IE11. If you're trying this sample from the local filesystem,
+                   it's easy to miss the prompt at the bottom of the window. */
+                display: block !important;
+            }
+        }
+	</style>
+  </head>
+
+  <body>
+    <!-- used to prompt selection of client certificate -->
+    <iframe id="iframe" src="" onload="iframeloaded()" hidden></iframe>
+
+    <div class="banner">
+      <div class="banner-interior">
+        <span class="logo">
+          <a href="http://dev.solace.com/">
+            <img src="../../resources/images/solace-logo-white.png"/>
+          </a>
+        </span>
+        <div class="banner-heading">
+          Solace Web Messaging API for JavaScript
+        </div>
+      </div>
+    </div>
+
+    <div class="doc-body">
+      <h2>Persistence with Queues tutorial</h2>
+      <h3>Queue Consumer</h3>
+      <!--[if IE]>
+          <div class="ie9 warning" style="padding: 5px; border: 1px solid black; background-color: #ff8;">
+              IE9 only: If you are running this sample from the local filesystem, click the "Allow blocked content" button
+              in the popup below to enable JavaScript.
+          </div>
+      <![endif]-->
+      <div class="ie11 warning">
+          IE 11 only: If you are running this sample from the local filesystem, click the "Allow blocked content" button
+          in the popup below to enable JavaScript.
+      </div>
+
+      <form class="pure-form pure-form-aligned">
+        <fieldset>
+
+          <div class="pure-control-group">
+            <label for="hosturl">Solace router host url</label>
+            <input id="hosturl" type="text" placeholder="<protocol://host[:port]>">
+          </div>
+
+          <div class="pure-control-group">
+            <label for="message-vpn">Message-vpn</label>
+            <input id="message-vpn" type="text" placeholder="Message VPN" value="default">
+          </div>
+
+          <div class="pure-control-group">
+            <label for="username">Username</label>
+            <input id="username" type="text" placeholder="Username">
+          </div>
+
+          <div class="pure-control-group">
+            <label for="password">Password</label>
+            <input id="password" type="password" placeholder="Password">
+          </div>
+
+        </fieldset>
+        <div class="box">
+          NOTE: Before you proceed, please ensure that the required queue is created on the Broker.
+        </div>
+        <p>
+          <button type="button" class="pure-button pure-button-primary" id="connect">Connect</button>
+          <button type="button" class="pure-button button-error" id="disconnect">Disconnect</button>
+        </p>
+        <p>
+          <button type="button" class="pure-button pure-button-primary" id="startconsume">Consume messages </button>
+          <button type="button" class="pure-button button-error" id="stopconsume">Stop consuming</button>
+          <button type="button" class="pure-button pure-button-secondary right" id="clear">Clear</button>
+        </p>
+        
+        <textarea id="log" rows="20" cols="90" autofocus></textarea>
+      </form>
+
+    </div>
+
+  </body>
+  
+</html>
+

--- a/src/features/QueueConsumer/QueueConsumer.html
+++ b/src/features/QueueConsumer/QueueConsumer.html
@@ -144,7 +144,7 @@
 
         </fieldset>
         <div class="box">
-          NOTE: Before you proceed, please ensure that the required queue is created on the Broker.
+          NOTE: Before you proceed, please ensure that the required queue is created on the message router vpn.
         </div>
         <p>
           <button type="button" class="pure-button pure-button-primary" id="connect">Connect</button>

--- a/src/features/QueueConsumer/QueueConsumer.html
+++ b/src/features/QueueConsumer/QueueConsumer.html
@@ -144,7 +144,7 @@
 
         </fieldset>
         <div class="box">
-          NOTE: Before you proceed, please ensure that the required queue is created on the message router vpn.
+          NOTE: Before you proceed, please ensure that the required queue is created on the Solace PubSub+ Event Broker.
         </div>
         <p>
           <button type="button" class="pure-button pure-button-primary" id="connect">Connect</button>

--- a/src/features/QueueConsumer/QueueConsumer.js
+++ b/src/features/QueueConsumer/QueueConsumer.js
@@ -47,8 +47,11 @@ var QueueConsumer = function (queueName) {
     };
 
     consumer.log('\n*** Consumer to queue "' + consumer.queueName + '" is ready to connect ***');
+    consumer.log('\n/*********************************************************************' +
+                  '\nNOTE: Ensure that the queue with appropriate subscription is created on the Broker.' +
+                  '\n/********************************************************************/')
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     consumer.connect = function () {
         if (consumer.session !== null) {
             consumer.log('Already connected and ready to consume messages.');
@@ -65,12 +68,12 @@ var QueueConsumer = function (queueName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            consumer.log('Cannot connect: please specify all the Solace message router properties.');
+            consumer.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        consumer.log('Connecting to Solace message router using url: ' + hosturl);
+        consumer.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         consumer.log('Client username: ' + username);
-        consumer.log('Solace message router VPN name: ' + vpn);
+        consumer.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             consumer.session = solace.SolclientFactory.createSession({
@@ -113,7 +116,7 @@ var QueueConsumer = function (queueName) {
         }
     };
 
-    // Starts consuming from a queue on Solace message router
+    // Starts consuming from a queue on Solace PubSub+ Event Broker
     consumer.startConsume = function () {
         if (consumer.session !== null) {
             if (consumer.consuming) {
@@ -159,11 +162,11 @@ var QueueConsumer = function (queueName) {
                 }
             }
         } else {
-            consumer.log('Cannot start the queue consumer because not connected to Solace message router.');
+            consumer.log('Cannot start the queue consumer because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Disconnects the consumer from queue on Solace message router
+    // Disconnects the consumer from queue on Solace PubSub+ Event Broker
     consumer.stopConsume = function () {
         if (consumer.session !== null) {
             if (consumer.consuming) {
@@ -180,13 +183,13 @@ var QueueConsumer = function (queueName) {
                     consumer.queueName + '"');
             }
         } else {
-            consumer.log('Cannot disconnect the consumer because not connected to Solace message router.');
+            consumer.log('Cannot disconnect the consumer because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     consumer.disconnect = function () {
-        consumer.log('Disconnecting from Solace message router...');
+        consumer.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (consumer.session !== null) {
             try {
                 consumer.session.disconnect();
@@ -194,7 +197,7 @@ var QueueConsumer = function (queueName) {
                 consumer.log(error.toString());
             }
         } else {
-            consumer.log('Not connected to Solace message router.');
+            consumer.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
 

--- a/src/features/QueueConsumer/QueueConsumer.js
+++ b/src/features/QueueConsumer/QueueConsumer.js
@@ -48,7 +48,7 @@ var QueueConsumer = function (queueName) {
 
     consumer.log('\n*** Consumer to queue "' + consumer.queueName + '" is ready to connect ***');
     consumer.log('\n/*********************************************************************' +
-                  '\nNOTE: Ensure that the queue with appropriate subscription is created on the Broker.' +
+                  '\nNOTE: Ensure that the required queue is created on the Broker.' +
                   '\n/********************************************************************/')
 
     // Establishes connection to Solace PubSub+ Event Broker
@@ -138,7 +138,7 @@ var QueueConsumer = function (queueName) {
                     consumer.messageConsumer.on(solace.MessageConsumerEventName.CONNECT_FAILED_ERROR, function () {
                         consumer.consuming = false;
                         consumer.log('=== Error: the message consumer could not bind to queue "' + consumer.queueName +
-                            '" ===\n   Ensure this queue exists on the message router vpn');
+                            '" ===\n   Ensure this queue exists on the Solace PubSub+ Event Broker');
                     });
                     consumer.messageConsumer.on(solace.MessageConsumerEventName.DOWN, function () {
                         consumer.consuming = false;

--- a/src/features/QueueConsumer/QueueConsumer.js
+++ b/src/features/QueueConsumer/QueueConsumer.js
@@ -199,6 +199,11 @@ var QueueConsumer = function (queueName) {
         }
     };
 
+    consumer.clear = function () {
+      consumer.log('Clearing log messages...');
+      document.getElementById('log').value = "";
+    }
+
     return consumer;
 };
 

--- a/src/features/QueueConsumer/QueueConsumer.js
+++ b/src/features/QueueConsumer/QueueConsumer.js
@@ -32,7 +32,6 @@ var QueueConsumer = function (queueName) {
     consumer.session = null;
     consumer.flow = null;
     consumer.queueName = queueName;
-    consumer.queueDestination = new solace.Destination(consumer.queueName, solace.DestinationType.QUEUE);
     consumer.consuming = false;
 
     // Logger

--- a/src/features/QueueProducer/QueueProducer.html
+++ b/src/features/QueueProducer/QueueProducer.html
@@ -59,6 +59,7 @@
         document.getElementById("connect").addEventListener("click", producer.connect);
         document.getElementById("disconnect").addEventListener("click", producer.disconnect);
         document.getElementById("publish").addEventListener("click", producer.sendMessage);
+        document.getElementById("clear").addEventListener("click", producer.clear);
       };
       function iframeloaded(){
         if (producer) {
@@ -140,12 +141,16 @@
           </div>
 
         </fieldset>
+        <div class="box">
+          NOTE: Before you proceed, please ensure that the required queue is created on the Broker.
+        </div>
         <p>
           <button type="button" class="pure-button pure-button-primary" id="connect">Connect</button>
           <button type="button" class="pure-button button-error" id="disconnect">Disconnect</button>
         </p>
         <p>
           <button type="button" class="pure-button pure-button-primary" id="publish">Send Message </button>
+          <button type="button" class="pure-button pure-button-secondary right" id="clear">Clear</button>
         </p>
         
         <textarea id="log" rows="20" cols="90" autofocus></textarea>

--- a/src/features/QueueProducer/QueueProducer.html
+++ b/src/features/QueueProducer/QueueProducer.html
@@ -141,9 +141,6 @@
           </div>
 
         </fieldset>
-        <div class="box">
-          NOTE: Before you proceed, please ensure that the required queue is created on the message router vpn.
-        </div>
         <p>
           <button type="button" class="pure-button pure-button-primary" id="connect">Connect</button>
           <button type="button" class="pure-button button-error" id="disconnect">Disconnect</button>

--- a/src/features/QueueProducer/QueueProducer.html
+++ b/src/features/QueueProducer/QueueProducer.html
@@ -142,7 +142,7 @@
 
         </fieldset>
         <div class="box">
-          NOTE: Before you proceed, please ensure that the required queue is created on the Broker.
+          NOTE: Before you proceed, please ensure that the required queue is created on the message router vpn.
         </div>
         <p>
           <button type="button" class="pure-button pure-button-primary" id="connect">Connect</button>

--- a/src/features/QueueProducer/QueueProducer.js
+++ b/src/features/QueueProducer/QueueProducer.js
@@ -46,7 +46,7 @@ var QueueProducer = function (queueName) {
 
     producer.log('\n*** Producer to queue "' + producer.queueName + '" is ready to connect ***');
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     producer.connect = function () {
         if (producer.session !== null) {
             producer.log('Already connected and ready to send messages.');
@@ -63,12 +63,12 @@ var QueueProducer = function (queueName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            producer.log('Cannot connect: please specify all the Solace message router properties.');
+            producer.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        producer.log('Connecting to Solace message router using url: ' + hosturl);
+        producer.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         producer.log('Client username: ' + username);
-        producer.log('Solace message router VPN name: ' + vpn);
+        producer.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             producer.session = solace.SolclientFactory.createSession({
@@ -132,7 +132,8 @@ var QueueProducer = function (queueName) {
             message.setDestination(solace.SolclientFactory.createDurableQueueDestination(producer.queueName));
             message.setBinaryAttachment(messageText);
             message.setDeliveryMode(solace.MessageDeliveryModeType.PERSISTENT);
-            // Define a correlation key object
+            // OPTIONAL: You can set a correlation key on the message and check for the correlation
+            // in the ACKNOWLEDGE_MESSAGE callback. Define a correlation key object
             const correlationKey = {
                 name: "MESSAGE_CORRELATIONKEY",
                 id: Date.now()
@@ -147,13 +148,13 @@ var QueueProducer = function (queueName) {
                 producer.log(error.toString());
             }
         } else {
-            producer.log('Cannot send messages because not connected to Solace message router.');
+            producer.log('Cannot send messages because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     producer.disconnect = function () {
-        producer.log('Disconnecting from Solace message router...');
+        producer.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (producer.session !== null) {
             try {
                 producer.session.disconnect();
@@ -161,7 +162,7 @@ var QueueProducer = function (queueName) {
                 producer.log(error.toString());
             }
         } else {
-            producer.log('Not connected to Solace message router.');
+            producer.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
 

--- a/src/features/README.md
+++ b/src/features/README.md
@@ -1,6 +1,6 @@
 # Solace JavaScript API advanced samples
 
-This directory contains code showing how to make use of advanced features of the Solace message router.
+This directory contains code showing how to make use of advanced features of the Solace PubSub+ Event Broker.
 
 The code requires JavaScript API version 10 or later.
 

--- a/src/features/README.md
+++ b/src/features/README.md
@@ -20,7 +20,7 @@ To learn more about specific features and details, refer to the [Solace develope
 
 * __DTEConsumer__: This sample shows how to consume messages from a Durable Topic Endpoint (DTE). The sample will associate the DTE with the topic "tutorial/topic", so the `basic-samples/TopicPublisher` app can be used to send messages to this topic.
 
-    *Prerequisite*: the DTE with the name "tutorial/dte" must have been provisioned on the message router vpn.  Ensure the DTE is enabled for both Incoming and Outgoing messages and set the Permission to at least 'Consume'.
+    *Prerequisite*: the DTE with the name "tutorial/dte" must have been provisioned on the Solace PubSub+ Event Broker.  Ensure the DTE is enabled for both Incoming and Outgoing messages and set the Permission to at least 'Consume'.
 
 * __EventMonitor__: This sample demonstrates how to use the special event monitoring topic subscriptions to build an application that monitors message router generated events. Start this sample then run any other sample app and observe a client connect event reported for that sample.
 

--- a/src/features/SecureSession/SecureSession.js
+++ b/src/features/SecureSession/SecureSession.js
@@ -47,7 +47,7 @@ var SecureTopicSubscriber = function (topicName) {
 
     subscriber.log('\n*** Secure Subscriber to topic "' + subscriber.topicName + '" is ready to connect ***');
 
-    // Establishes connection to Solace message router
+    // Establishes connection to Solace PubSub+ Event Broker
     subscriber.connect = function () {
         if (subscriber.session !== null) {
             subscriber.log('Already connected and ready to subscribe.');
@@ -63,12 +63,12 @@ var SecureTopicSubscriber = function (topicName) {
         var pass = document.getElementById('password').value;
         var vpn = document.getElementById('message-vpn').value;
         if (!hosturl || !username || !pass || !vpn) {
-            subscriber.log('Cannot connect: please specify all the Solace message router properties.');
+            subscriber.log('Cannot connect: please specify all the Solace PubSub+ Event Broker properties.');
             return;
         }
-        subscriber.log('Connecting to Solace message router using url: ' + hosturl);
+        subscriber.log('Connecting to Solace PubSub+ Event Broker using url: ' + hosturl);
         subscriber.log('Client username: ' + username);
-        subscriber.log('Solace message router VPN name: ' + vpn);
+        subscriber.log('Solace PubSub+ Event Broker VPN name: ' + vpn);
         // create session
         try {
             subscriber.session = solace.SolclientFactory.createSession({
@@ -131,7 +131,7 @@ var SecureTopicSubscriber = function (topicName) {
         }
     };
 
-    // Subscribes to topic on Solace message router
+    // Subscribes to topic on Solace PubSub+ Event Broker
     subscriber.subscribe = function () {
         if (subscriber.session !== null) {
             if (subscriber.subscribed) {
@@ -151,11 +151,11 @@ var SecureTopicSubscriber = function (topicName) {
                 }
             }
         } else {
-            subscriber.log('Cannot subscribe because not connected to Solace message router.');
+            subscriber.log('Cannot subscribe because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Unsubscribes from topic on Solace message router
+    // Unsubscribes from topic on Solace PubSub+ Event Broker
     subscriber.unsubscribe = function () {
         if (subscriber.session !== null) {
             if (subscriber.subscribed) {
@@ -175,13 +175,13 @@ var SecureTopicSubscriber = function (topicName) {
                     subscriber.topicName + '"');
             }
         } else {
-            subscriber.log('Cannot unsubscribe because not connected to Solace message router.');
+            subscriber.log('Cannot unsubscribe because not connected to Solace PubSub+ Event Broker.');
         }
     };
 
-    // Gracefully disconnects from Solace message router
+    // Gracefully disconnects from Solace PubSub+ Event Broker
     subscriber.disconnect = function () {
-        subscriber.log('Disconnecting from Solace message router...');
+        subscriber.log('Disconnecting from Solace PubSub+ Event Broker...');
         if (subscriber.session !== null) {
             try {
                 subscriber.session.disconnect();
@@ -189,7 +189,7 @@ var SecureTopicSubscriber = function (topicName) {
                 subscriber.log(error.toString());
             }
         } else {
-            subscriber.log('Not connected to Solace message router.');
+            subscriber.log('Not connected to Solace PubSub+ Event Broker.');
         }
     };
 

--- a/src/resources/css/samples.css
+++ b/src/resources/css/samples.css
@@ -41,3 +41,20 @@ body {
 label {
     margin-right:     15px;
 }
+
+#log {
+  width: 100%;
+}
+
+.right {
+  float: right;
+}
+
+.box {
+  padding: 1em;
+  margin-bottom: 1rem;
+  font-weight: bold;
+  font-style: italic;
+  background-color: #e6e6e6;
+  border: 1px solid #d3d3d3;
+}


### PR DESCRIPTION
The goal is to bring JS samples on par with JCSMP samples 
- Guaranteed publisher/Subscriber 
- Queue producer/consumer

Changes:
  - Modified QueueProducer & QueueConsumer to work with Topic subscriptions
  - Moved QueueProducer & Consumer to features
  - Added Guaranteed Publisher & Subscriber aligned with convention-based topic solace/samples/js/pers/pub/*
Updated the HTML & CSS with additional instruction (pre-requisite) and a clear button to unclutter the textarea
