### PR TITLE
Issue 60 - Update samples to use Factory Profile 10_5

### DIFF
--- a/src/basic-samples/BasicReplier/BasicReplier.html
+++ b/src/basic-samples/BasicReplier/BasicReplier.html
@@ -45,7 +45,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/basic-samples/BasicRequestor/BasicRequestor.html
+++ b/src/basic-samples/BasicRequestor/BasicRequestor.html
@@ -46,7 +46,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/basic-samples/ConfirmedPublish/ConfirmedPublish.html
+++ b/src/basic-samples/ConfirmedPublish/ConfirmedPublish.html
@@ -46,7 +46,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/basic-samples/ConfirmedPublish/ConfirmedPublish.js
+++ b/src/basic-samples/ConfirmedPublish/ConfirmedPublish.js
@@ -134,9 +134,11 @@ var QueueProducer = function (queueName) {
     // Sends one message
     producer.sendMessage = function (sequenceNr) {
         var messageText = 'Sample Message';
+        // var binaryPayload = new TextEncoder().encode(messageText);
         var message = solace.SolclientFactory.createMessage();
         message.setDestination(solace.SolclientFactory.createDurableQueueDestination(producer.queueName));
-        message.setBinaryAttachment(messageText);
+        message.setSdtContainer(solace.SDTField.create(solace.SDTFieldType.STRING, messageText));  // TextMessage
+        // message.setBinaryAttachment(binaryPayload);  // BytesMessage
         message.setDeliveryMode(solace.MessageDeliveryModeType.PERSISTENT);
         // Define a correlation key object
         const correlationKey = {

--- a/src/basic-samples/GuaranteedPublisher/GuaranteedPublisher.html
+++ b/src/basic-samples/GuaranteedPublisher/GuaranteedPublisher.html
@@ -46,7 +46,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/basic-samples/GuaranteedPublisher/GuaranteedPublisher.js
+++ b/src/basic-samples/GuaranteedPublisher/GuaranteedPublisher.js
@@ -127,8 +127,10 @@ var GuaranteedPublisher = function (topicName) {
     publisher.publish = function () {
         if (publisher.session !== null) {
             var messageText = 'Sample Message';
+            var binaryPayload = new TextEncoder().encode(messageText);
             var message = solace.SolclientFactory.createMessage();
-            message.setBinaryAttachment(messageText);
+            // message.setSdtContainer(solace.SDTField.create(solace.SDTFieldType.STRING, messageText));  // TextMesage
+            message.setBinaryAttachment(binaryPayload);  // BytesMessage
             message.setDeliveryMode(solace.MessageDeliveryModeType.PERSISTENT);
             // OPTIONAL: You can set a correlation key on the message and check for the correlation
             // in the ACKNOWLEDGE_MESSAGE callback. Define a correlation key object

--- a/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.html
+++ b/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.html
@@ -46,7 +46,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.js
+++ b/src/basic-samples/GuaranteedSubscriber/GuaranteedSubscriber.js
@@ -164,8 +164,13 @@ var GuaranteedSubscriber = function (queueName, topicName) {
                     });
                     // Define message received event listener
                     subscriber.messageSubscriber.on(solace.MessageConsumerEventName.MESSAGE, function (message) {
-                        subscriber.log('Received message: "' + message.getBinaryAttachment() + '",' +
-                            ' details:\n' + message.dump());
+                        if (message.getType() == solace.MessageType.TEXT) {  // in case someone sends text message
+                            var payload = message.getSdtContainer().getValue();
+                            subscriber.log('Received TextMessage: "' + payload + '", details:\n' + message.dump());
+                        } else {
+                            subscriber.log('Received message: "' + message.getBinaryAttachment() +
+                                    '", details:\n' + message.dump());
+                        }
                         // Need to explicitly ack otherwise it will not be deleted from the message router
                         message.acknowledge();
                     });

--- a/src/basic-samples/TopicPublisher/TopicPublisher.html
+++ b/src/basic-samples/TopicPublisher/TopicPublisher.html
@@ -46,7 +46,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/basic-samples/TopicPublisher/TopicPublisher.js
+++ b/src/basic-samples/TopicPublisher/TopicPublisher.js
@@ -115,9 +115,11 @@ var TopicPublisher = function (topicName) {
     publisher.publish = function () {
         if (publisher.session !== null) {
             var messageText = 'Sample Message';
+            // var binaryPayload = new TextEncoder().encode(messageText);
             var message = solace.SolclientFactory.createMessage();
             message.setDestination(solace.SolclientFactory.createTopicDestination(publisher.topicName));
-            message.setBinaryAttachment(messageText);
+            message.setSdtContainer(solace.SDTField.create(solace.SDTFieldType.STRING, messageText));  // TextMesage
+            // message.setBinaryAttachment(binaryPayload);  // BytesMessage
             message.setDeliveryMode(solace.MessageDeliveryModeType.DIRECT);
             publisher.log('Publishing message "' + messageText + '" to topic "' + publisher.topicName + '"...');
             try {

--- a/src/basic-samples/TopicSubscriber/TopicSubscriber.html
+++ b/src/basic-samples/TopicSubscriber/TopicSubscriber.html
@@ -45,7 +45,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/basic-samples/TopicSubscriber/TopicSubscriber.js
+++ b/src/basic-samples/TopicSubscriber/TopicSubscriber.js
@@ -114,12 +114,15 @@ var TopicSubscriber = function (topicName) {
         });
         // define message event listener
         subscriber.session.on(solace.SessionEventCode.MESSAGE, function (message) {
-            subscriber.log('Received message: "' + message.getBinaryAttachment() + '", details:\n' +
-                message.dump());
+            if (message.getType() == solace.MessageType.TEXT) {  // in case someone sends text message
+                var payload = message.getSdtContainer().getValue();
+                subscriber.log('Received TextMessage: "' + payload + '", details:\n' + message.dump());
+            } else {
+                subscriber.log('Received message: "' + message.getBinaryAttachment() +
+                        '", details:\n' + message.dump());
+            }
         });
-
-
-       subscriber.connectToSolace();   
+        subscriber.connectToSolace();   
 
 
 

--- a/src/features/ActiveConsumerIndication/ActiveConsumerIndication.html
+++ b/src/features/ActiveConsumerIndication/ActiveConsumerIndication.html
@@ -45,7 +45,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/features/DTEConsumer/DTEConsumer.html
+++ b/src/features/DTEConsumer/DTEConsumer.html
@@ -45,7 +45,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/features/DTEConsumer/DTEConsumer.js
+++ b/src/features/DTEConsumer/DTEConsumer.js
@@ -156,8 +156,13 @@ var DTEConsumer = function (topicEndpointName, topicName) {
                     });
                     // Define message event listener
                     consumer.messageConsumer.on(solace.MessageConsumerEventName.MESSAGE, function (message) {
-                        consumer.log('Received message: "' + message.getBinaryAttachment() + '",' +
-                            ' details:\n' + message.dump());
+                        if (message.getType() == solace.MessageType.TEXT) {  // in case someone sends text message
+                            var payload = message.getSdtContainer().getValue();
+                            consumer.log('Received TextMessage: "' + payload + '", details:\n' + message.dump());
+                        } else {
+                            consumer.log('Received message: "' + message.getBinaryAttachment() +
+                                    '", details:\n' + message.dump());
+                       }
                     });
                     // Connect the message consumer
                     consumer.messageConsumer.connect();

--- a/src/features/EventMonitor/EventMonitor.html
+++ b/src/features/EventMonitor/EventMonitor.html
@@ -45,7 +45,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/features/EventMonitor/EventMonitor.js
+++ b/src/features/EventMonitor/EventMonitor.js
@@ -122,6 +122,7 @@ var EventSubscriber = function () {
         });
         // define message event listener
         subscriber.session.on(solace.SessionEventCode.MESSAGE, function (message) {
+            // Broker event log over the message bus sent as BytesMessage with string payload
             subscriber.log('Received Client Connect event: "' + message.getBinaryAttachment());
         });
 

--- a/src/features/GuaranteedReplier/GuaranteedReplier.html
+++ b/src/features/GuaranteedReplier/GuaranteedReplier.html
@@ -45,7 +45,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/features/GuaranteedRequestor/GuaranteedRequestor.html
+++ b/src/features/GuaranteedRequestor/GuaranteedRequestor.html
@@ -45,7 +45,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/features/MessageReplay/MessageReplay.html
+++ b/src/features/MessageReplay/MessageReplay.html
@@ -46,7 +46,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/features/MessageReplay/MessageReplay.js
+++ b/src/features/MessageReplay/MessageReplay.js
@@ -205,8 +205,13 @@ var QueueConsumer = function (queueName) {
             });
             // Define message received event listener
             consumer.messageConsumer.on(solace.MessageConsumerEventName.MESSAGE, function (message) {
-                consumer.log('Received message: "' + message.getBinaryAttachment() + '",' +
-                    ' details:\n' + message.dump());
+                if (message.getType() == solace.MessageType.TEXT) {  // in case someone sends text message
+                    var payload = message.getSdtContainer().getValue();
+                    consumer.log('Received TextMessage: "' + payload + '", details:\n' + message.dump());
+                } else {
+                    consumer.log('Received message: "' + message.getBinaryAttachment() +
+                            '", details:\n' + message.dump());
+                }
                 // Need to explicitly ack otherwise it will not be deleted from the message router
                 message.acknowledge();
             });

--- a/src/features/NoLocalPubSub/NoLocalPubSub.html
+++ b/src/features/NoLocalPubSub/NoLocalPubSub.html
@@ -45,7 +45,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/features/QueueConsumer/QueueConsumer.html
+++ b/src/features/QueueConsumer/QueueConsumer.html
@@ -46,7 +46,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/features/QueueConsumer/QueueConsumer.js
+++ b/src/features/QueueConsumer/QueueConsumer.js
@@ -148,8 +148,13 @@ var QueueConsumer = function (queueName) {
                     });
                     // Define message received event listener
                     consumer.messageConsumer.on(solace.MessageConsumerEventName.MESSAGE, function (message) {
-                        consumer.log('Received message: "' + message.getBinaryAttachment() + '",' +
-                            ' details:\n' + message.dump());
+                        if (message.getType() == solace.MessageType.TEXT) {  // in case someone sends text message
+                            var payload = message.getSdtContainer().getValue();
+                            consumer.log('Received TextMessage: "' + payload + '", details:\n' + message.dump());
+                        } else {
+                            consumer.log('Received message: "' + message.getBinaryAttachment() +
+                                '", details:\n' + message.dump());
+                        }
                         // Need to explicitly ack otherwise it will not be deleted from the message router
                         message.acknowledge();
                     });

--- a/src/features/QueueProducer/QueueProducer.html
+++ b/src/features/QueueProducer/QueueProducer.html
@@ -46,7 +46,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/features/QueueProducer/QueueProducer.js
+++ b/src/features/QueueProducer/QueueProducer.js
@@ -127,10 +127,12 @@ var QueueProducer = function (queueName) {
     producer.sendMessage = function () {
         if (producer.session !== null) {
             var messageText = 'Sample Message';
+            var binaryPayload = new TextEncoder().encode(messageText);
             var message = solace.SolclientFactory.createMessage();
             producer.log('Sending message "' + messageText + '" to queue "' + producer.queueName + '"...');
             message.setDestination(solace.SolclientFactory.createDurableQueueDestination(producer.queueName));
-            message.setBinaryAttachment(messageText);
+            // message.setSdtContainer(solace.SDTField.create(solace.SDTFieldType.STRING, messageText));  // TextMesage
+            message.setBinaryAttachment(binaryPayload);  // BytesMessage
             message.setDeliveryMode(solace.MessageDeliveryModeType.PERSISTENT);
             // OPTIONAL: You can set a correlation key on the message and check for the correlation
             // in the ACKNOWLEDGE_MESSAGE callback. Define a correlation key object

--- a/src/features/SecureSession/SecureSession.html
+++ b/src/features/SecureSession/SecureSession.html
@@ -45,7 +45,7 @@
       window.onload = function () {
         // Initialize factory with the most recent API defaults
         var factoryProps = new solace.SolclientFactoryProperties();
-        factoryProps.profile = solace.SolclientFactoryProfiles.version10;
+        factoryProps.profile = solace.SolclientFactoryProfiles.version10_5;
         solace.SolclientFactory.init(factoryProps);
 
         // enable logging to JavaScript console at WARN level

--- a/src/features/SecureSession/SecureSession.js
+++ b/src/features/SecureSession/SecureSession.js
@@ -114,8 +114,13 @@ var SecureTopicSubscriber = function (topicName) {
         });
         // define message event listener
         subscriber.session.on(solace.SessionEventCode.MESSAGE, function (message) {
-            subscriber.log('Received message: "' + message.getBinaryAttachment() + '", details:\n' +
-                message.dump());
+            if (message.getType() == solace.MessageType.TEXT) {  // in case someone sends text message
+                var payload = message.getSdtContainer().getValue();
+                subscriber.log('Received TextMessage: "' + payload + '", details:\n' + message.dump());
+            } else {
+                subscriber.log('Received message: "' + message.getBinaryAttachment() +
+                        '", details:\n' + message.dump());
+            }
         });
         // if secure connection, first load iframe so the browser can provide a client-certificate
         var urlNoProto = hosturl.split('/').slice(2).join('/'); // remove protocol prefix


### PR DESCRIPTION
This should have been done a long time ago.  Factory profile 10_5 changed how raw binary payloads were encoded when using a BytesMessage... moving from a latin-1 encoded String to a UInt8Array.  These updates should make it easier for users of our JS API to use current best practices and help reduce confusion.

Additionally, included some helpful "if/else" blocks in various consumer or subscriber apps for checking if a TextMessage (SDT) was received, or a BytesMessage, and handling it properly.  And also on the publisher side, including example lines for publishing either a raw BytesMessage or an SDT TextMessage.
